### PR TITLE
feat: add polling-based SessionUpdateReceiver for SDK

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -160,6 +160,17 @@ export { EventEmitter, createEventEmitter } from "./events";
 // Session Reader
 export { SessionReader } from "./session-reader";
 
+// Session Update Receiver
+export {
+  SessionUpdateReceiver,
+  createSessionReceiver,
+  type SessionUpdate,
+  type ReceiverOptions,
+} from "./receiver";
+
+// Re-export TranscriptEvent from polling/parser for SDK consumers
+export { type TranscriptEvent } from "../polling/parser";
+
 // JSONL Parser
 export {
   parseJsonl,

--- a/src/sdk/receiver.test.ts
+++ b/src/sdk/receiver.test.ts
@@ -1,0 +1,571 @@
+/**
+ * Tests for SessionUpdateReceiver.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionUpdateReceiver, createSessionReceiver } from "./receiver";
+
+describe("SessionUpdateReceiver", () => {
+  let tempDir: string;
+  let transcriptPath: string;
+
+  beforeEach(async () => {
+    // Create a unique temp directory for each test
+    tempDir = await mkdtemp(join(tmpdir(), "receiver-test-"));
+    transcriptPath = join(tempDir, "transcript.jsonl");
+  });
+
+  afterEach(async () => {
+    // Clean up temp directory
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("createSessionReceiver", () => {
+    test("returns a SessionUpdateReceiver instance", () => {
+      const receiver = createSessionReceiver("test-session");
+      expect(receiver).toBeInstanceOf(SessionUpdateReceiver);
+      receiver.close();
+    });
+
+    test("sets sessionId correctly", () => {
+      const receiver = createSessionReceiver("test-session-123");
+      expect(receiver.sessionId).toBe("test-session-123");
+      receiver.close();
+    });
+  });
+
+  describe("isClosed property", () => {
+    test("is initially false", () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+      });
+      expect(receiver.isClosed).toBe(false);
+      receiver.close();
+    });
+
+    test("is true after close()", () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+      });
+      receiver.close();
+      expect(receiver.isClosed).toBe(true);
+    });
+  });
+
+  describe("close()", () => {
+    test("sets isClosed to true", () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+      });
+      receiver.close();
+      expect(receiver.isClosed).toBe(true);
+    });
+
+    test("causes receive() to return null", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+      });
+      receiver.close();
+      const result = await receiver.receive();
+      expect(result).toBe(null);
+    });
+
+    test("can be called multiple times safely", () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+      });
+      receiver.close();
+      receiver.close();
+      expect(receiver.isClosed).toBe(true);
+    });
+  });
+
+  describe("receive() with new content", () => {
+    test("picks up new content written to transcript file", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      // Write content after a short delay
+      setTimeout(async () => {
+        await writeFile(
+          transcriptPath,
+          '{"type":"user","content":"Hello"}\n',
+          "utf8",
+        );
+      }, 100);
+
+      const update = await receiver.receive();
+      expect(update).not.toBe(null);
+      expect(update?.newContent).toBe('{"type":"user","content":"Hello"}\n');
+      expect(update?.events).toHaveLength(1);
+      expect(update?.events[0]?.type).toBe("user");
+
+      receiver.close();
+    });
+
+    test("picks up multiple sequential writes", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      // Write first content
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"First"}\n',
+        "utf8",
+      );
+
+      const update1 = await receiver.receive();
+      expect(update1?.events).toHaveLength(1);
+      expect(update1?.events[0]?.type).toBe("user");
+
+      // Write second content
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"First"}\n{"type":"assistant","content":"Second"}\n',
+        "utf8",
+      );
+
+      const update2 = await receiver.receive();
+      expect(update2?.events).toHaveLength(1);
+      expect(update2?.events[0]?.type).toBe("assistant");
+
+      receiver.close();
+    });
+
+    test("handles rapid writes correctly", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      // Write initial content
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"Line1"}\n',
+        "utf8",
+      );
+
+      // First receive picks up the initial write
+      const update1 = await receiver.receive();
+      expect(update1?.events[0]?.type).toBe("user");
+
+      // Append more content after first receive
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"Line1"}\n{"type":"assistant","content":"Line2"}\n',
+        "utf8",
+      );
+
+      // Second receive picks up only the new content
+      const update2 = await receiver.receive();
+      expect(update2?.events[0]?.type).toBe("assistant");
+
+      receiver.close();
+    });
+  });
+
+  describe("receive() with includeExisting", () => {
+    test("returns existing content on first call when includeExisting: true", async () => {
+      // Write content before creating receiver
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"Existing"}\n',
+        "utf8",
+      );
+
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        includeExisting: true,
+        pollingIntervalMs: 50,
+      });
+
+      const update = await receiver.receive();
+      expect(update).not.toBe(null);
+      expect(update?.events).toHaveLength(1);
+      expect(update?.events[0]?.type).toBe("user");
+
+      receiver.close();
+    });
+
+    test("does not return existing content when includeExisting: false", async () => {
+      // Write content before creating receiver
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"Existing"}\n',
+        "utf8",
+      );
+
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        includeExisting: false,
+        pollingIntervalMs: 50,
+      });
+
+      // Write new content after delay
+      setTimeout(async () => {
+        await writeFile(
+          transcriptPath,
+          '{"type":"user","content":"Existing"}\n{"type":"assistant","content":"New"}\n',
+          "utf8",
+        );
+      }, 100);
+
+      const update = await receiver.receive();
+      expect(update).not.toBe(null);
+      expect(update?.events).toHaveLength(1);
+      expect(update?.events[0]?.type).toBe("assistant");
+
+      receiver.close();
+    });
+  });
+
+  describe("custom polling interval", () => {
+    test("respects custom pollingIntervalMs", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 200,
+      });
+
+      const startTime = Date.now();
+
+      // Write content that should be picked up
+      setTimeout(async () => {
+        await writeFile(
+          transcriptPath,
+          '{"type":"user","content":"Test"}\n',
+          "utf8",
+        );
+      }, 50);
+
+      await receiver.receive();
+      const elapsed = Date.now() - startTime;
+
+      // Should take at least one polling interval
+      expect(elapsed).toBeGreaterThanOrEqual(50);
+
+      receiver.close();
+    });
+  });
+
+  describe("file not existing yet", () => {
+    test("waits until file appears", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      // Create file after delay
+      setTimeout(async () => {
+        await writeFile(
+          transcriptPath,
+          '{"type":"user","content":"Delayed"}\n',
+          "utf8",
+        );
+      }, 150);
+
+      const update = await receiver.receive();
+      expect(update).not.toBe(null);
+      expect(update?.events).toHaveLength(1);
+      expect(update?.events[0]?.type).toBe("user");
+
+      receiver.close();
+    });
+
+    test("handles file created and deleted multiple times", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      // Create file
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"First"}\n',
+        "utf8",
+      );
+
+      const update1 = await receiver.receive();
+      expect(update1?.events[0]?.type).toBe("user");
+
+      // Delete file and wait for at least one poll cycle to detect it
+      await rm(transcriptPath, { force: true });
+      await new Promise((resolve) => setTimeout(resolve, 120));
+
+      // Recreate file with new content
+      await writeFile(
+        transcriptPath,
+        '{"type":"assistant","content":"Second"}\n',
+        "utf8",
+      );
+
+      const update2 = await receiver.receive();
+      expect(update2?.events[0]?.type).toBe("assistant");
+
+      receiver.close();
+    });
+  });
+
+  describe("file truncation", () => {
+    test("resets offset when file is smaller than offset", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      // Write initial content
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"Initial long content"}\n',
+        "utf8",
+      );
+
+      const update1 = await receiver.receive();
+      expect(update1?.events).toHaveLength(1);
+
+      // Truncate file (write shorter content)
+      await writeFile(
+        transcriptPath,
+        '{"type":"assistant","content":"Short"}\n',
+        "utf8",
+      );
+
+      const update2 = await receiver.receive();
+      expect(update2).not.toBe(null);
+      expect(update2?.events[0]?.type).toBe("assistant");
+
+      receiver.close();
+    });
+  });
+
+  describe("multiple sequential receive() calls", () => {
+    test("queues updates when multiple updates arrive", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      // Write initial content
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"Line1"}\n',
+        "utf8",
+      );
+
+      // First receive picks up initial write
+      const update1 = await receiver.receive();
+      expect(update1?.events[0]?.type).toBe("user");
+
+      // Append new content after first receive
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"Line1"}\n{"type":"assistant","content":"Line2"}\n',
+        "utf8",
+      );
+
+      // Second receive picks up appended content
+      const update2 = await receiver.receive();
+      expect(update2?.events[0]?.type).toBe("assistant");
+
+      receiver.close();
+    });
+
+    test("blocks when no updates available", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      let receivedUpdate = false;
+
+      // Start receive (will block)
+      const receivePromise = receiver.receive().then((update) => {
+        receivedUpdate = true;
+        return update;
+      });
+
+      // Verify it's blocking
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(receivedUpdate).toBe(false);
+
+      // Write content to unblock
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"Unblock"}\n',
+        "utf8",
+      );
+
+      const update = await receivePromise;
+      expect(update).not.toBe(null);
+      expect(receivedUpdate).toBe(true);
+
+      receiver.close();
+    });
+  });
+
+  describe("sessionId property", () => {
+    test("returns the correct session ID", () => {
+      const receiver = createSessionReceiver("my-session-id", {
+        transcriptPath,
+      });
+      expect(receiver.sessionId).toBe("my-session-id");
+      receiver.close();
+    });
+  });
+
+  describe("timestamp in updates", () => {
+    test("includes valid ISO timestamp", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      await writeFile(
+        transcriptPath,
+        '{"type":"user","content":"Test"}\n',
+        "utf8",
+      );
+
+      const update = await receiver.receive();
+      expect(update).not.toBe(null);
+      expect(update?.timestamp).toBeDefined();
+
+      // Validate ISO format
+      if (update !== null) {
+        const timestamp = new Date(update.timestamp);
+        expect(timestamp.toISOString()).toBe(update.timestamp);
+      }
+
+      receiver.close();
+    });
+  });
+
+  describe("events parsing", () => {
+    test("parses multiple events correctly", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      const content =
+        '{"type":"user","content":"Message1"}\n' +
+        '{"type":"assistant","content":"Message2"}\n' +
+        '{"type":"tool_use","name":"Read"}\n';
+
+      await writeFile(transcriptPath, content, "utf8");
+
+      const update = await receiver.receive();
+      expect(update).not.toBe(null);
+      expect(update?.events).toHaveLength(3);
+      expect(update?.events[0]?.type).toBe("user");
+      expect(update?.events[1]?.type).toBe("assistant");
+      expect(update?.events[2]?.type).toBe("tool_use");
+
+      receiver.close();
+    });
+
+    test("handles malformed JSON gracefully", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      const content =
+        '{"type":"user","content":"Valid"}\n' +
+        "{invalid json}\n" +
+        '{"type":"assistant","content":"AlsoValid"}\n';
+
+      await writeFile(transcriptPath, content, "utf8");
+
+      const update = await receiver.receive();
+      expect(update).not.toBe(null);
+      // Malformed line is skipped
+      expect(update?.events).toHaveLength(2);
+      expect(update?.events[0]?.type).toBe("user");
+      expect(update?.events[1]?.type).toBe("assistant");
+
+      receiver.close();
+    });
+  });
+
+  describe("close() during pending receive()", () => {
+    test("resolves pending receive() with null when closed", async () => {
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      // Start receive (will block since no content)
+      const receivePromise = receiver.receive();
+
+      // Close after delay
+      setTimeout(() => {
+        receiver.close();
+      }, 100);
+
+      const result = await receivePromise;
+      expect(result).toBe(null);
+    });
+  });
+
+  describe("empty file", () => {
+    test("waits for content even if file exists but is empty", async () => {
+      // Create empty file
+      await writeFile(transcriptPath, "", "utf8");
+
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        pollingIntervalMs: 50,
+      });
+
+      // Write content after delay
+      setTimeout(async () => {
+        await writeFile(
+          transcriptPath,
+          '{"type":"user","content":"Content"}\n',
+          "utf8",
+        );
+      }, 100);
+
+      const update = await receiver.receive();
+      expect(update).not.toBe(null);
+      expect(update?.events).toHaveLength(1);
+
+      receiver.close();
+    });
+  });
+
+  describe("includeExisting with empty file", () => {
+    test("does not enqueue empty content when includeExisting: true", async () => {
+      // Create empty file
+      await writeFile(transcriptPath, "", "utf8");
+
+      const receiver = createSessionReceiver("test-session", {
+        transcriptPath,
+        includeExisting: true,
+        pollingIntervalMs: 50,
+      });
+
+      // Write content after delay
+      setTimeout(async () => {
+        await writeFile(
+          transcriptPath,
+          '{"type":"user","content":"New"}\n',
+          "utf8",
+        );
+      }, 100);
+
+      const update = await receiver.receive();
+      expect(update).not.toBe(null);
+      expect(update?.events[0]?.type).toBe("user");
+
+      receiver.close();
+    });
+  });
+});

--- a/src/sdk/receiver.ts
+++ b/src/sdk/receiver.ts
@@ -1,0 +1,423 @@
+/**
+ * Polling-based session update receiver.
+ *
+ * Provides a pull-based API for receiving updates from Claude Code session
+ * transcript files. This is an alternative to the AsyncIterable patterns,
+ * offering a simpler interface for applications that prefer polling.
+ *
+ * @module sdk/receiver
+ */
+
+import { readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { JsonlStreamParser, type TranscriptEvent } from "../polling/parser";
+
+/**
+ * SessionUpdate represents one batch of updates from a poll cycle.
+ *
+ * Each update contains new content read since the last poll,
+ * parsed events, and a timestamp.
+ */
+export interface SessionUpdate {
+  /** Session ID this update belongs to */
+  readonly sessionId: string;
+  /** Raw new JSONL content since last poll */
+  readonly newContent: string;
+  /** Parsed events from new content */
+  readonly events: readonly TranscriptEvent[];
+  /** ISO timestamp of this update */
+  readonly timestamp: string;
+}
+
+/**
+ * Configuration options for SessionUpdateReceiver.
+ */
+export interface ReceiverOptions {
+  /** Polling interval in milliseconds (default: 300) */
+  readonly pollingIntervalMs?: number | undefined;
+  /** Whether to include existing content on first receive (default: true) */
+  readonly includeExisting?: boolean | undefined;
+  /** Override auto-resolved transcript path */
+  readonly transcriptPath?: string | undefined;
+}
+
+/**
+ * SessionUpdateReceiver provides a polling-based API for receiving session updates.
+ *
+ * This class polls the Claude Code session transcript file at a configurable
+ * interval and returns batches of new content via the receive() method.
+ *
+ * Features:
+ * - Lazy initialization - polling starts on first receive() call
+ * - File offset tracking - only reads new content
+ * - Handles missing files - waits for file to appear
+ * - Handles file truncation - resets offset when detected
+ * - Queue-based - multiple receive() calls are queued
+ *
+ * @example
+ * ```typescript
+ * const receiver = createSessionReceiver("session-uuid-here", {
+ *   pollingIntervalMs: 300,
+ * });
+ *
+ * while (true) {
+ *   const update = await receiver.receive();
+ *   if (update === null) break; // receiver closed
+ *
+ *   console.log(`Got ${update.events.length} new events`);
+ *   for (const event of update.events) {
+ *     console.log(`  ${event.type}: ${JSON.stringify(event.content)}`);
+ *   }
+ * }
+ *
+ * receiver.close();
+ * ```
+ */
+/**
+ * Internal options with all values resolved to non-undefined.
+ */
+interface ResolvedReceiverOptions {
+  readonly pollingIntervalMs: number;
+  readonly includeExisting: boolean;
+  readonly transcriptPath: string;
+}
+
+export class SessionUpdateReceiver {
+  private readonly _sessionId: string;
+  private readonly options: ResolvedReceiverOptions;
+  private readonly transcriptPath: string;
+
+  private _isClosed: boolean = false;
+  private _isPolling: boolean = false;
+  private pollingTimer: Timer | null = null;
+  private fileOffset: number = 0;
+  private parser: JsonlStreamParser = new JsonlStreamParser();
+
+  private readonly updateQueue: SessionUpdate[] = [];
+  private pendingReceive: ((value: SessionUpdate | null) => void) | null = null;
+
+  private readonly firstReceiveHandled: { value: boolean } = { value: false };
+
+  /**
+   * Create a new SessionUpdateReceiver.
+   *
+   * Polling starts lazily on the first receive() call.
+   *
+   * @param sessionId - Session ID to monitor
+   * @param options - Receiver configuration
+   */
+  constructor(sessionId: string, options?: ReceiverOptions) {
+    this._sessionId = sessionId;
+
+    const defaultTranscriptPath = join(
+      homedir(),
+      ".claude",
+      "sessions",
+      sessionId,
+      "transcript.jsonl",
+    );
+
+    this.options = {
+      pollingIntervalMs: options?.pollingIntervalMs ?? 300,
+      includeExisting: options?.includeExisting ?? true,
+      transcriptPath: options?.transcriptPath ?? defaultTranscriptPath,
+    };
+
+    this.transcriptPath = this.options.transcriptPath;
+  }
+
+  /**
+   * Get the session ID being monitored.
+   */
+  get sessionId(): string {
+    return this._sessionId;
+  }
+
+  /**
+   * Check if the receiver is closed.
+   */
+  get isClosed(): boolean {
+    return this._isClosed;
+  }
+
+  /**
+   * Receive the next batch of updates.
+   *
+   * This method blocks (via Promise) until new content is available.
+   * Returns null when the receiver is closed.
+   *
+   * On the first call:
+   * - If includeExisting is true, returns existing content immediately
+   * - If includeExisting is false, starts polling and waits for new content
+   *
+   * @returns Next update batch, or null if closed
+   *
+   * @example
+   * ```typescript
+   * const update = await receiver.receive();
+   * if (update === null) {
+   *   console.log("Receiver closed");
+   * } else {
+   *   console.log(`Received ${update.events.length} events`);
+   * }
+   * ```
+   */
+  async receive(): Promise<SessionUpdate | null> {
+    if (this._isClosed) {
+      return null;
+    }
+
+    // Start polling on first receive() call
+    if (!this._isPolling) {
+      await this.startPolling();
+    }
+
+    // Check if there are queued updates
+    const queued = this.updateQueue.shift();
+    if (queued !== undefined) {
+      return queued;
+    }
+
+    // Wait for next update
+    return new Promise<SessionUpdate | null>((resolve) => {
+      this.pendingReceive = resolve;
+    });
+  }
+
+  /**
+   * Close the receiver and stop polling.
+   *
+   * Any pending receive() calls will return null.
+   * After closing, subsequent receive() calls return null immediately.
+   *
+   * This is the recommended way to stop monitoring a session.
+   *
+   * @example
+   * ```typescript
+   * receiver.close();
+   * const update = await receiver.receive(); // Returns null
+   * ```
+   */
+  close(): void {
+    if (this._isClosed) {
+      return;
+    }
+
+    this._isClosed = true;
+    this._isPolling = false;
+
+    // Clear polling timer
+    if (this.pollingTimer !== null) {
+      clearInterval(this.pollingTimer);
+      this.pollingTimer = null;
+    }
+
+    // Resolve any pending receive() with null
+    if (this.pendingReceive !== null) {
+      this.pendingReceive(null);
+      this.pendingReceive = null;
+    }
+
+    // Clear queue
+    this.updateQueue.length = 0;
+  }
+
+  /**
+   * Start the polling mechanism.
+   *
+   * Handles includeExisting logic and sets up the interval timer.
+   * @private
+   */
+  private async startPolling(): Promise<void> {
+    this._isPolling = true;
+
+    // Handle includeExisting option
+    if (!this.firstReceiveHandled.value) {
+      this.firstReceiveHandled.value = true;
+
+      if (this.options.includeExisting) {
+        // includeExisting: true - return existing content immediately
+        await this.handleIncludeExisting();
+      } else {
+        // includeExisting: false - skip existing content by setting offset
+        await this.skipExistingContent();
+      }
+    }
+
+    // Start polling timer
+    this.pollingTimer = setInterval(() => {
+      void this.poll();
+    }, this.options.pollingIntervalMs);
+
+    // Run first poll immediately
+    void this.poll();
+  }
+
+  /**
+   * Skip existing content when includeExisting is false.
+   * Sets offset to current file size and feeds content to parser.
+   * @private
+   */
+  private async skipExistingContent(): Promise<void> {
+    try {
+      const fileStat = await stat(this.transcriptPath);
+      this.fileOffset = fileStat.size;
+      // Feed existing content to parser to keep it in sync
+      if (fileStat.size > 0) {
+        const existingContent = await readFile(this.transcriptPath, "utf8");
+        this.parser.feed(existingContent);
+      }
+    } catch {
+      // File doesn't exist yet, that's okay
+    }
+  }
+
+  /**
+   * Handle includeExisting: true on first receive.
+   *
+   * Reads entire file content and enqueues as an update if non-empty.
+   * @private
+   */
+  private async handleIncludeExisting(): Promise<void> {
+    try {
+      // Get file stat first
+      const fileStat = await stat(this.transcriptPath);
+
+      // If file is empty, just set offset and return
+      if (fileStat.size === 0) {
+        this.fileOffset = 0;
+        return;
+      }
+
+      // Read entire file
+      const content = await readFile(this.transcriptPath, "utf8");
+
+      // Parse content
+      const events = this.parser.feed(content);
+
+      // Update offset BEFORE flushing, so subsequent polls read from the right place
+      this.fileOffset = fileStat.size;
+
+      // Create update
+      const update: SessionUpdate = {
+        sessionId: this._sessionId,
+        newContent: content,
+        events,
+        timestamp: new Date().toISOString(),
+      };
+
+      // Enqueue or resolve pending
+      this.enqueueOrResolvePending(update);
+    } catch {
+      // File doesn't exist yet, that's okay
+      // Poll will pick it up later
+    }
+  }
+
+  /**
+   * Execute one poll cycle.
+   *
+   * Reads new content from the transcript file and enqueues updates.
+   * Handles missing files and file truncation gracefully.
+   * @private
+   */
+  private async poll(): Promise<void> {
+    if (this._isClosed) {
+      return;
+    }
+
+    try {
+      // Check if file exists
+      const fileStat = await stat(this.transcriptPath);
+
+      // Handle file truncation
+      if (fileStat.size < this.fileOffset) {
+        this.fileOffset = 0;
+        this.parser = new JsonlStreamParser();
+      }
+
+      // Check if there's new content
+      if (fileStat.size === this.fileOffset) {
+        return; // No new content
+      }
+
+      // Read entire file
+      const content = await readFile(this.transcriptPath, "utf8");
+
+      // Extract new content from offset
+      const newContent = content.slice(this.fileOffset);
+
+      if (newContent.length === 0) {
+        return; // No new content
+      }
+
+      // Parse new content
+      const events = this.parser.feed(newContent);
+
+      // Update offset
+      this.fileOffset = fileStat.size;
+
+      // Create update
+      const update: SessionUpdate = {
+        sessionId: this._sessionId,
+        newContent,
+        events,
+        timestamp: new Date().toISOString(),
+      };
+
+      // Enqueue or resolve pending
+      this.enqueueOrResolvePending(update);
+    } catch {
+      // File doesn't exist yet or read error
+      // Reset offset so next read starts from beginning if file reappears
+      this.fileOffset = 0;
+      this.parser = new JsonlStreamParser();
+    }
+  }
+
+  /**
+   * Enqueue an update or resolve pending receive() immediately.
+   * @private
+   */
+  private enqueueOrResolvePending(update: SessionUpdate): void {
+    if (this.pendingReceive !== null) {
+      // Resolve pending receive() immediately
+      const resolver = this.pendingReceive;
+      this.pendingReceive = null;
+      resolver(update);
+    } else {
+      // Queue for later
+      this.updateQueue.push(update);
+    }
+  }
+}
+
+/**
+ * Create a new SessionUpdateReceiver.
+ *
+ * This is a factory function that creates a receiver instance.
+ * Polling starts lazily on the first receive() call.
+ *
+ * @param sessionId - Session ID to monitor
+ * @param options - Receiver configuration
+ * @returns New SessionUpdateReceiver instance
+ *
+ * @example
+ * ```typescript
+ * const receiver = createSessionReceiver("session-uuid", {
+ *   pollingIntervalMs: 500,
+ *   includeExisting: true,
+ * });
+ *
+ * for await (const update of receiveUpdates(receiver)) {
+ *   console.log(update);
+ * }
+ * ```
+ */
+export function createSessionReceiver(
+  sessionId: string,
+  options?: ReceiverOptions,
+): SessionUpdateReceiver {
+  return new SessionUpdateReceiver(sessionId, options);
+}


### PR DESCRIPTION
## Summary

- Add `SessionUpdateReceiver` class providing a pull-based `receive()` API for monitoring Claude Code session transcript files via periodic polling
- Add `createSessionReceiver(sessionId, options?)` factory function for standalone session observation by session ID
- Export new types (`SessionUpdate`, `ReceiverOptions`, `TranscriptEvent`) from SDK public API

## Motivation

The existing session monitoring APIs (`TranscriptWatcher`, `SessionMonitor`) use `fs.watch` and `AsyncIterable` patterns which require `for await...of` loops. Some SDK consumers need a simpler pull-based pattern:

```typescript
const receiver = createSessionReceiver("session-uuid", {
  pollingIntervalMs: 300,
});

while (true) {
  const update = await receiver.receive();
  if (update === null) break;
  console.log(update.events);
}
```

The receiver uses periodic file polling (default 0.3s, configurable) instead of `fs.watch`, and works standalone without DI container setup.

## Key Design Decisions

- **Polling over fs.watch**: Configurable interval (default 300ms), more portable and predictable
- **Lazy initialization**: Polling starts on first `receive()` call, not on construction
- **Lightweight**: Uses `node:fs/promises` directly, no Container/DI dependency required
- **Graceful edge cases**: Handles missing files (waits), file truncation (resets), file deletion/recreation (re-reads from start)

## File Changes

| File | Change | Description |
|------|--------|-------------|
| `src/sdk/receiver.ts` | A | SessionUpdateReceiver class, factory function, types |
| `src/sdk/receiver.test.ts` | A | 25 tests covering core and edge cases |
| `src/sdk/index.ts` | M | Export new types from SDK public API |

## Test plan

- [x] TypeScript type check passing (tsc --noEmit)
- [x] 25 unit tests passing (bun test)
- [ ] Manual integration test with live Claude Code session