### PR TITLE
Add MockSessionUpdateReceiver for SDK Testing

### DIFF
--- a/src/sdk/__fixtures__/mock-receiver.test.ts
+++ b/src/sdk/__fixtures__/mock-receiver.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Tests for MockSessionUpdateReceiver.
+ */
+
+import { describe, test, expect } from "vitest";
+import {
+  MockSessionUpdateReceiver,
+  createMockSessionReceiver,
+} from "./mock-receiver";
+import type { SessionUpdate } from "../receiver";
+import type { TranscriptEvent } from "../../polling/parser";
+
+describe("MockSessionUpdateReceiver", () => {
+  describe("createMockSessionReceiver", () => {
+    test("returns a MockSessionUpdateReceiver instance", () => {
+      const mock = createMockSessionReceiver("test-session");
+      expect(mock).toBeInstanceOf(MockSessionUpdateReceiver);
+      mock.close();
+    });
+
+    test("sets sessionId correctly", () => {
+      const mock = createMockSessionReceiver("my-session-id");
+      expect(mock.sessionId).toBe("my-session-id");
+      mock.close();
+    });
+  });
+
+  describe("initial state", () => {
+    test("isClosed is false initially", () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      expect(mock.isClosed).toBe(false);
+      mock.close();
+    });
+
+    test("queueSize is 0 initially", () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      expect(mock.queueSize).toBe(0);
+      mock.close();
+    });
+
+    test("hasPendingReceive is false initially", () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      expect(mock.hasPendingReceive).toBe(false);
+      mock.close();
+    });
+  });
+
+  describe("close()", () => {
+    test("sets isClosed to true", () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      mock.close();
+      expect(mock.isClosed).toBe(true);
+    });
+
+    test("causes receive() to return null", async () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      mock.close();
+      const result = await mock.receive();
+      expect(result).toBe(null);
+    });
+
+    test("can be called multiple times safely", () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      mock.close();
+      mock.close();
+      expect(mock.isClosed).toBe(true);
+    });
+
+    test("resolves pending receive() with null", async () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      const receivePromise = mock.receive();
+
+      expect(mock.hasPendingReceive).toBe(true);
+
+      mock.close();
+
+      const result = await receivePromise;
+      expect(result).toBe(null);
+    });
+
+    test("clears queued updates", () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      const update: SessionUpdate = {
+        sessionId: "test",
+        newContent: "content",
+        events: [],
+        timestamp: new Date().toISOString(),
+      };
+      mock.pushUpdate(update);
+      expect(mock.queueSize).toBe(1);
+      mock.close();
+      expect(mock.queueSize).toBe(0);
+    });
+  });
+
+  describe("pushUpdate()", () => {
+    test("queues update when no pending receive", () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      const update: SessionUpdate = {
+        sessionId: "test",
+        newContent: '{"type":"user"}\n',
+        events: [],
+        timestamp: new Date().toISOString(),
+      };
+      mock.pushUpdate(update);
+      expect(mock.queueSize).toBe(1);
+      mock.close();
+    });
+
+    test("resolves pending receive immediately", async () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      const receivePromise = mock.receive();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mock.hasPendingReceive).toBe(true);
+
+      const update: SessionUpdate = {
+        sessionId: "test",
+        newContent: '{"type":"user","content":"Hello"}\n',
+        events: [
+          {
+            type: "user",
+            raw: { type: "user", content: "Hello" },
+          } as TranscriptEvent,
+        ],
+        timestamp: new Date().toISOString(),
+      };
+
+      mock.pushUpdate(update);
+
+      const result = await receivePromise;
+      expect(result).not.toBe(null);
+      expect(result?.sessionId).toBe("test");
+      expect(result?.events).toHaveLength(1);
+
+      mock.close();
+    });
+
+    test("throws when receiver is closed", () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      mock.close();
+
+      const update: SessionUpdate = {
+        sessionId: "test",
+        newContent: "content",
+        events: [],
+        timestamp: new Date().toISOString(),
+      };
+
+      expect(() => mock.pushUpdate(update)).toThrow(
+        "Cannot push update to closed mock receiver",
+      );
+    });
+
+    test("multiple updates are queued in order", async () => {
+      const mock = new MockSessionUpdateReceiver("test");
+
+      const update1: SessionUpdate = {
+        sessionId: "test",
+        newContent: "first",
+        events: [],
+        timestamp: "2026-01-01T00:00:00.000Z",
+      };
+      const update2: SessionUpdate = {
+        sessionId: "test",
+        newContent: "second",
+        events: [],
+        timestamp: "2026-01-01T00:00:01.000Z",
+      };
+
+      mock.pushUpdate(update1);
+      mock.pushUpdate(update2);
+      expect(mock.queueSize).toBe(2);
+
+      const result1 = await mock.receive();
+      expect(result1?.newContent).toBe("first");
+
+      const result2 = await mock.receive();
+      expect(result2?.newContent).toBe("second");
+
+      mock.close();
+    });
+  });
+
+  describe("pushEvents()", () => {
+    test("creates SessionUpdate from events", async () => {
+      const mock = new MockSessionUpdateReceiver("test-session");
+
+      const events: TranscriptEvent[] = [
+        {
+          type: "user",
+          raw: { type: "user", content: "Hello" },
+        } as TranscriptEvent,
+        {
+          type: "assistant",
+          raw: { type: "assistant", content: "Hi there" },
+        } as TranscriptEvent,
+      ];
+
+      mock.pushEvents(events);
+
+      const update = await mock.receive();
+      expect(update).not.toBe(null);
+      expect(update?.sessionId).toBe("test-session");
+      expect(update?.events).toHaveLength(2);
+      expect(update?.events[0]?.type).toBe("user");
+      expect(update?.events[1]?.type).toBe("assistant");
+      expect(update?.timestamp).toBeDefined();
+
+      mock.close();
+    });
+
+    test("auto-generates newContent from events", async () => {
+      const mock = new MockSessionUpdateReceiver("test");
+
+      const events: TranscriptEvent[] = [
+        {
+          type: "user",
+          raw: { type: "user", content: "Hello" },
+        } as TranscriptEvent,
+      ];
+
+      mock.pushEvents(events);
+
+      const update = await mock.receive();
+      expect(update?.newContent).toBe('{"type":"user","content":"Hello"}\n');
+
+      mock.close();
+    });
+
+    test("uses custom content when provided", async () => {
+      const mock = new MockSessionUpdateReceiver("test");
+
+      const events: TranscriptEvent[] = [
+        {
+          type: "user",
+          raw: { type: "user", content: "Hello" },
+        } as TranscriptEvent,
+      ];
+
+      mock.pushEvents(events, "custom content here");
+
+      const update = await mock.receive();
+      expect(update?.newContent).toBe("custom content here");
+
+      mock.close();
+    });
+
+    test("throws when receiver is closed", () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      mock.close();
+
+      expect(() => mock.pushEvents([])).toThrow(
+        "Cannot push update to closed mock receiver",
+      );
+    });
+  });
+
+  describe("receive()", () => {
+    test("returns queued updates in FIFO order", async () => {
+      const mock = new MockSessionUpdateReceiver("test");
+
+      mock.pushEvents([
+        { type: "user", raw: { type: "user" } } as TranscriptEvent,
+      ]);
+      mock.pushEvents([
+        {
+          type: "assistant",
+          raw: { type: "assistant" },
+        } as TranscriptEvent,
+      ]);
+
+      const r1 = await mock.receive();
+      const r2 = await mock.receive();
+
+      expect(r1?.events[0]?.type).toBe("user");
+      expect(r2?.events[0]?.type).toBe("assistant");
+
+      mock.close();
+    });
+
+    test("blocks until update is pushed", async () => {
+      const mock = new MockSessionUpdateReceiver("test");
+
+      let received = false;
+      const receivePromise = mock.receive().then((update) => {
+        received = true;
+        return update;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(received).toBe(false);
+      expect(mock.hasPendingReceive).toBe(true);
+
+      mock.pushEvents([
+        { type: "user", raw: { type: "user" } } as TranscriptEvent,
+      ]);
+
+      const result = await receivePromise;
+      expect(received).toBe(true);
+      expect(result?.events[0]?.type).toBe("user");
+
+      mock.close();
+    });
+
+    test("returns null immediately when closed", async () => {
+      const mock = new MockSessionUpdateReceiver("test");
+      mock.close();
+
+      const result = await mock.receive();
+      expect(result).toBe(null);
+    });
+  });
+
+  describe("ISessionUpdateReceiver compatibility", () => {
+    test("can be used where ISessionUpdateReceiver is expected", async () => {
+      const mock: import("../receiver").ISessionUpdateReceiver =
+        new MockSessionUpdateReceiver("test");
+
+      expect(mock.sessionId).toBe("test");
+      expect(mock.isClosed).toBe(false);
+
+      mock.close();
+      expect(mock.isClosed).toBe(true);
+
+      const result = await mock.receive();
+      expect(result).toBe(null);
+    });
+  });
+});

--- a/src/sdk/__fixtures__/mock-receiver.ts
+++ b/src/sdk/__fixtures__/mock-receiver.ts
@@ -1,0 +1,158 @@
+/**
+ * Mock SessionUpdateReceiver for unit testing.
+ *
+ * Provides programmatic injection of session updates without filesystem dependency.
+ * Follows the same queue-based receive pattern as the real SessionUpdateReceiver.
+ *
+ * @module sdk/__fixtures__/mock-receiver
+ */
+
+import type { TranscriptEvent } from "../../polling/parser";
+import type { ISessionUpdateReceiver, SessionUpdate } from "../receiver";
+
+/**
+ * Mock SessionUpdateReceiver for unit testing.
+ *
+ * Simulates session update reception without polling the filesystem.
+ * Updates can be injected via pushUpdate() and pushEvents() methods.
+ *
+ * @example
+ * ```typescript
+ * const mock = new MockSessionUpdateReceiver("test-session");
+ *
+ * // Push an update
+ * mock.pushUpdate({
+ *   sessionId: "test-session",
+ *   newContent: '{"type":"user","content":"Hello"}\n',
+ *   events: [{ type: "user", raw: { type: "user", content: "Hello" } }],
+ *   timestamp: new Date().toISOString(),
+ * });
+ *
+ * const update = await mock.receive();
+ * // update contains the pushed data
+ *
+ * mock.close();
+ * ```
+ */
+export class MockSessionUpdateReceiver implements ISessionUpdateReceiver {
+  private readonly _sessionId: string;
+  private _isClosed: boolean = false;
+  private readonly updateQueue: SessionUpdate[] = [];
+  private pendingReceive: ((value: SessionUpdate | null) => void) | null = null;
+
+  constructor(sessionId: string) {
+    this._sessionId = sessionId;
+  }
+
+  get sessionId(): string {
+    return this._sessionId;
+  }
+
+  get isClosed(): boolean {
+    return this._isClosed;
+  }
+
+  async receive(): Promise<SessionUpdate | null> {
+    if (this._isClosed) {
+      return null;
+    }
+
+    const queued = this.updateQueue.shift();
+    if (queued !== undefined) {
+      return queued;
+    }
+
+    return new Promise<SessionUpdate | null>((resolve) => {
+      this.pendingReceive = resolve;
+    });
+  }
+
+  close(): void {
+    if (this._isClosed) {
+      return;
+    }
+
+    this._isClosed = true;
+
+    if (this.pendingReceive !== null) {
+      this.pendingReceive(null);
+      this.pendingReceive = null;
+    }
+
+    this.updateQueue.length = 0;
+  }
+
+  // --- Mock-specific methods ---
+
+  /**
+   * Push a complete SessionUpdate into the receiver.
+   *
+   * If a receive() call is pending, it resolves immediately.
+   * Otherwise the update is queued for the next receive() call.
+   *
+   * @param update - The update to inject
+   * @throws Error if receiver is closed
+   */
+  pushUpdate(update: SessionUpdate): void {
+    if (this._isClosed) {
+      throw new Error("Cannot push update to closed mock receiver");
+    }
+
+    if (this.pendingReceive !== null) {
+      const resolver = this.pendingReceive;
+      this.pendingReceive = null;
+      resolver(update);
+    } else {
+      this.updateQueue.push(update);
+    }
+  }
+
+  /**
+   * Convenience method to push events without constructing a full SessionUpdate.
+   *
+   * Automatically generates sessionId, timestamp, and newContent from events.
+   *
+   * @param events - Array of TranscriptEvent to include
+   * @param content - Optional raw JSONL content override
+   * @throws Error if receiver is closed
+   */
+  pushEvents(events: readonly TranscriptEvent[], content?: string): void {
+    const newContent =
+      content ?? events.map((e) => JSON.stringify(e.raw)).join("\n") + "\n";
+
+    const update: SessionUpdate = {
+      sessionId: this._sessionId,
+      newContent,
+      events,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.pushUpdate(update);
+  }
+
+  /**
+   * Check if there is a pending receive() call waiting for data.
+   */
+  get hasPendingReceive(): boolean {
+    return this.pendingReceive !== null;
+  }
+
+  /**
+   * Get the number of queued updates waiting to be received.
+   */
+  get queueSize(): number {
+    return this.updateQueue.length;
+  }
+}
+
+/**
+ * Factory function for creating MockSessionUpdateReceiver instances.
+ *
+ * @param sessionId - Session ID for the mock receiver
+ * @returns New MockSessionUpdateReceiver instance
+ */
+export function createMockSessionReceiver(
+  sessionId: string,
+): MockSessionUpdateReceiver {
+  return new MockSessionUpdateReceiver(sessionId);
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -164,9 +164,16 @@ export { SessionReader } from "./session-reader";
 export {
   SessionUpdateReceiver,
   createSessionReceiver,
+  type ISessionUpdateReceiver,
   type SessionUpdate,
   type ReceiverOptions,
 } from "./receiver";
+
+// Mock Session Update Receiver (for testing)
+export {
+  MockSessionUpdateReceiver,
+  createMockSessionReceiver,
+} from "./__fixtures__/mock-receiver";
 
 // Re-export TranscriptEvent from polling/parser for SDK consumers
 export { type TranscriptEvent } from "../polling/parser";

--- a/src/sdk/receiver.ts
+++ b/src/sdk/receiver.ts
@@ -43,6 +43,19 @@ export interface ReceiverOptions {
 }
 
 /**
+ * Interface for session update receivers.
+ *
+ * Both the real SessionUpdateReceiver and MockSessionUpdateReceiver
+ * implement this interface, enabling test substitution.
+ */
+export interface ISessionUpdateReceiver {
+  readonly sessionId: string;
+  readonly isClosed: boolean;
+  receive(): Promise<SessionUpdate | null>;
+  close(): void;
+}
+
+/**
  * SessionUpdateReceiver provides a polling-based API for receiving session updates.
  *
  * This class polls the Claude Code session transcript file at a configurable
@@ -83,7 +96,7 @@ interface ResolvedReceiverOptions {
   readonly transcriptPath: string;
 }
 
-export class SessionUpdateReceiver {
+export class SessionUpdateReceiver implements ISessionUpdateReceiver {
   private readonly _sessionId: string;
   private readonly options: ResolvedReceiverOptions;
   private readonly transcriptPath: string;


### PR DESCRIPTION
## Summary

This PR adds a mock implementation of SessionUpdateReceiver to enable unit testing of SDK-consuming applications without filesystem dependencies. The mock provides programmatic injection of session updates while maintaining the same ISessionUpdateReceiver interface contract as the polling-based implementation.

## Changes

- Introduced `ISessionUpdateReceiver` interface that both `SessionUpdateReceiver` and `MockSessionUpdateReceiver` implement, enabling type-safe substitution in application code
- Implemented `MockSessionUpdateReceiver` class with queue-based update delivery pattern matching the real receiver's behavior
- Added `pushUpdate()` and `pushEvents()` methods for programmatic test data injection with automatic JSONL content generation
- Included test introspection methods (`hasPendingReceive`, `queueSize`) for asserting receiver state without exposing internal implementation details
- Exported factory function `createMockSessionReceiver()` for convenient mock instantiation
- Documented mock receiver usage patterns and interface contract in SDK API specification
- Provided comprehensive test suite with 22 tests covering factory function, initial state, close behavior, queue management, pending receive resolution, and interface compatibility

## Changed Files

| File | Additions | Deletions | Change Summary |
| ---- | --------- | --------- | -------------- |
| src/sdk/__fixtures__/mock-receiver.test.ts | 330 | 0 | Add comprehensive test suite |
| src/sdk/__fixtures__/mock-receiver.ts | 158 | 0 | Implement mock receiver class |
| design-docs/spec-sdk-api.md | 113 | 0 | Document mock receiver API |
| src/sdk/receiver.ts | 14 | 1 | Extract interface for substitution |
| src/sdk/index.ts | 7 | 0 | Export mock receiver types |

## Technical Details

### Interface-Based Design Pattern

The key architectural decision was extracting `ISessionUpdateReceiver` interface to enable dependency injection and test substitution. Both production (`SessionUpdateReceiver`) and test (`MockSessionUpdateReceiver`) implementations share the same contract:

```typescript
interface ISessionUpdateReceiver {
  readonly sessionId: string;
  readonly isClosed: boolean;
  receive(): Promise<SessionUpdate | null>;
  close(): void;
}
```

This allows application code to accept `ISessionUpdateReceiver` and work seamlessly with either implementation.

### Queue-Based Asynchronous Pattern

The mock replicates the real receiver's queue-based behavior where:
- `receive()` blocks (returns Promise) when no updates are queued
- `pushUpdate()` resolves pending receives immediately or enqueues for later
- `close()` resolves all pending receives with `null` and clears the queue

This ensures tests accurately simulate the real receiver's asynchronous characteristics.

### Automatic JSONL Generation

The `pushEvents()` convenience method auto-generates JSONL content from TranscriptEvent arrays by serializing each event's raw field:

```typescript
mock.pushEvents([
  { type: "user", raw: { type: "user", content: "Hello" } }
]);
// Generates: {"type":"user","content":"Hello"}\n
```

This simplifies test setup while maintaining format consistency with real transcript files.

### Test Introspection

Mock-specific getters (`hasPendingReceive`, `queueSize`) enable state assertions without exposing internal implementation:

```typescript
mock.receive(); // Start async receive
expect(mock.hasPendingReceive).toBe(true);

mock.pushUpdate(update);
expect(mock.queueSize).toBe(0); // Resolved immediately
```

## Related Issues/PRs

No related issues or PRs.

---

## Additional Notes

<!-- You can edit this section freely from the web interface -->
<!-- This section will be preserved when running /git-pr -->

This implementation enables SDK consumers to write fast, deterministic unit tests for their SessionUpdateReceiver integration logic without creating actual filesystem transcript files or introducing polling delays. Tests can verify application behavior under various scenarios like single updates, queued updates, concurrent receives, and close conditions.
