### PR TITLE
feat: session resume, transcript reading, type exports, and integration examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,59 @@
+# Integration Examples
+
+Examples for integrating `claude-code-agent` SDK with web frameworks and frontend libraries.
+
+## Examples
+
+### `hono-rest-api.ts`
+
+REST API using [Hono](https://hono.dev/) framework. Demonstrates:
+- Session listing with pagination
+- Session detail retrieval
+- Transcript reading with offset/limit
+- SSE streaming endpoint
+
+### `sse-bridge.ts`
+
+Server-Sent Events bridge using Bun.serve. Demonstrates:
+- Converting `SessionUpdateReceiver` polling into SSE streams
+- Proper SSE message formatting with event types and IDs
+- Client disconnect handling
+
+### `svelte5-store.ts`
+
+[Svelte 5](https://svelte.dev/) integration patterns. Demonstrates:
+- Reactive store with `$state` bridge pattern
+- `$derived` values for computed properties
+- Full component example with `onMount`/`onDestroy` lifecycle
+
+### `react-integration.tsx`
+
+[React 18+](https://react.dev/) integration. Demonstrates:
+- `useSyncExternalStore` pattern for concurrent rendering safety
+- Custom `useSessionUpdates` hook
+- Complete `SessionViewer` component
+
+## Prerequisites
+
+```bash
+# Install the SDK
+bun add claude-code-agent
+
+# For Hono example
+bun add hono
+
+# For React example
+bun add react @types/react
+```
+
+## Running Examples
+
+```bash
+# Hono REST API (port 3000)
+bun run examples/hono-rest-api.ts
+
+# SSE Bridge (port 3001)
+bun run examples/sse-bridge.ts
+```
+
+The Svelte and React examples are reference patterns meant to be adapted into your application's component structure.

--- a/examples/hono-rest-api.ts
+++ b/examples/hono-rest-api.ts
@@ -1,0 +1,160 @@
+/**
+ * Hono REST API Integration Example
+ *
+ * Demonstrates how to wire SessionReader and SessionUpdateReceiver
+ * into Hono route handlers for building session monitoring REST APIs.
+ *
+ * Prerequisites:
+ *   bun add hono claude-code-agent
+ *
+ * @example
+ * ```bash
+ * bun run examples/hono-rest-api.ts
+ * ```
+ */
+
+import { Hono } from "hono";
+import {
+  SessionReader,
+  SessionUpdateReceiver,
+  type SessionUpdate,
+  type TranscriptEvent,
+} from "claude-code-agent/sdk";
+import { createContainer } from "claude-code-agent/container";
+
+// --- Setup ---
+
+const app = new Hono();
+const container = createContainer();
+const reader = new SessionReader(container);
+
+// --- Routes ---
+
+/**
+ * GET /sessions
+ * List all sessions with optional filtering and pagination.
+ *
+ * Query parameters:
+ *   - projectPath: Filter by project directory
+ *   - offset: Skip N sessions (default: 0)
+ *   - limit: Return at most N sessions (default: 50)
+ */
+app.get("/sessions", async (c) => {
+  const projectPath = c.req.query("projectPath");
+  const offset = parseInt(c.req.query("offset") ?? "0", 10);
+  const limit = parseInt(c.req.query("limit") ?? "50", 10);
+
+  const allSessions = await reader.listSessions(projectPath);
+
+  // Apply pagination
+  const paginated = allSessions.slice(offset, offset + limit);
+
+  return c.json({
+    sessions: paginated,
+    total: allSessions.length,
+    offset,
+    limit,
+  });
+});
+
+/**
+ * GET /sessions/:id
+ * Get full session details including messages.
+ */
+app.get("/sessions/:id", async (c) => {
+  const sessionId = c.req.param("id");
+  const session = await reader.getSession(sessionId);
+
+  if (!session) {
+    return c.json({ error: "Session not found" }, 404);
+  }
+
+  return c.json(session);
+});
+
+/**
+ * GET /sessions/:id/messages
+ * Get messages for a specific session.
+ */
+app.get("/sessions/:id/messages", async (c) => {
+  const sessionId = c.req.param("id");
+  const messages = await reader.getMessages(sessionId);
+
+  return c.json({ messages });
+});
+
+/**
+ * GET /sessions/:id/transcript
+ * Get raw transcript events with pagination.
+ *
+ * Query parameters:
+ *   - offset: Skip N events (default: 0)
+ *   - limit: Return at most N events (default: 100)
+ */
+app.get("/sessions/:id/transcript", async (c) => {
+  const sessionId = c.req.param("id");
+  const offset = parseInt(c.req.query("offset") ?? "0", 10);
+  const limit = parseInt(c.req.query("limit") ?? "100", 10);
+
+  const result = await reader.readTranscript(sessionId, { offset, limit });
+
+  if (result.isErr()) {
+    return c.json({ error: result.error.message }, 404);
+  }
+
+  return c.json(result.value);
+});
+
+/**
+ * GET /sessions/:id/stream
+ * Stream session updates via Server-Sent Events.
+ * See sse-bridge.ts for the full SSE implementation.
+ */
+app.get("/sessions/:id/stream", async (c) => {
+  const sessionId = c.req.param("id");
+
+  return c.newResponse(
+    new ReadableStream({
+      async start(controller) {
+        const encoder = new TextEncoder();
+        const receiver = new SessionUpdateReceiver(sessionId, {
+          pollingIntervalMs: 300,
+          includeExisting: true,
+        });
+
+        try {
+          while (true) {
+            const update: SessionUpdate | null = await receiver.receive();
+            if (update === null) {
+              break;
+            }
+
+            for (const event of update.events) {
+              const data = JSON.stringify(event);
+              controller.enqueue(
+                encoder.encode(`data: ${data}\n\n`),
+              );
+            }
+          }
+        } finally {
+          receiver.close();
+          controller.close();
+        }
+      },
+    }),
+    {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    },
+  );
+});
+
+// --- Start server ---
+
+export default {
+  port: 3000,
+  fetch: app.fetch,
+};

--- a/examples/react-integration.tsx
+++ b/examples/react-integration.tsx
@@ -1,0 +1,301 @@
+/**
+ * React Integration Example
+ *
+ * Demonstrates how to consume SessionUpdateReceiver in React
+ * using useSyncExternalStore and custom hooks.
+ *
+ * Prerequisites:
+ *   bun add claude-code-agent react
+ *
+ * NOTE: This file requires React 18+ for useSyncExternalStore.
+ */
+
+import { useSyncExternalStore, useCallback, useEffect, useRef } from "react";
+import type {
+  TranscriptEvent,
+  SessionUpdate,
+  ISessionUpdateReceiver,
+} from "claude-code-agent/sdk";
+import { SessionUpdateReceiver } from "claude-code-agent/sdk";
+
+// ============================================================
+// Pattern 1: External Store for useSyncExternalStore
+// ============================================================
+
+/**
+ * SessionStore wraps SessionUpdateReceiver as a React-compatible
+ * external store using the useSyncExternalStore pattern.
+ *
+ * This is the recommended approach for React 18+ as it properly
+ * handles concurrent rendering and avoids tearing.
+ */
+class SessionStore {
+  private receiver: ISessionUpdateReceiver | null = null;
+  private events: readonly TranscriptEvent[] = [];
+  private connected: boolean = false;
+  private error: string | null = null;
+  private listeners: Set<() => void> = new Set();
+  private polling: boolean = false;
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly options?: {
+      pollingIntervalMs?: number;
+      includeExisting?: boolean;
+    },
+  ) {}
+
+  /**
+   * Subscribe to store changes.
+   * Called by useSyncExternalStore.
+   */
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+
+    // Start polling on first subscriber
+    if (this.listeners.size === 1 && !this.polling) {
+      void this.start();
+    }
+
+    return () => {
+      this.listeners.delete(listener);
+
+      // Stop polling when no subscribers
+      if (this.listeners.size === 0) {
+        this.stop();
+      }
+    };
+  };
+
+  /**
+   * Get current snapshot for useSyncExternalStore.
+   * Returns a stable reference that only changes when data changes.
+   */
+  getSnapshot = (): SessionStoreSnapshot => {
+    return {
+      events: this.events,
+      connected: this.connected,
+      error: this.error,
+      sessionId: this.sessionId,
+    };
+  };
+
+  /**
+   * Server-side snapshot for SSR.
+   */
+  getServerSnapshot = (): SessionStoreSnapshot => {
+    return {
+      events: [],
+      connected: false,
+      error: null,
+      sessionId: this.sessionId,
+    };
+  };
+
+  private async start(): Promise<void> {
+    this.receiver = new SessionUpdateReceiver(this.sessionId, {
+      pollingIntervalMs: this.options?.pollingIntervalMs ?? 300,
+      includeExisting: this.options?.includeExisting ?? true,
+    });
+
+    this.connected = true;
+    this.polling = true;
+    this.notify();
+
+    while (this.polling && this.receiver !== null) {
+      try {
+        const update: SessionUpdate | null = await this.receiver.receive();
+
+        if (update === null) {
+          this.connected = false;
+          this.notify();
+          break;
+        }
+
+        // Create new array reference to trigger React re-render
+        this.events = [...this.events, ...update.events];
+        this.error = null;
+        this.notify();
+      } catch (err) {
+        this.error = err instanceof Error ? err.message : String(err);
+        this.notify();
+      }
+    }
+  }
+
+  private stop(): void {
+    this.polling = false;
+    if (this.receiver !== null) {
+      this.receiver.close();
+      this.receiver = null;
+    }
+    this.connected = false;
+    this.notify();
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+/**
+ * Immutable snapshot of the session store state.
+ */
+interface SessionStoreSnapshot {
+  readonly events: readonly TranscriptEvent[];
+  readonly connected: boolean;
+  readonly error: string | null;
+  readonly sessionId: string;
+}
+
+// ============================================================
+// Pattern 2: Custom Hook
+// ============================================================
+
+/**
+ * useSessionUpdates - React hook for consuming session updates.
+ *
+ * Uses useSyncExternalStore internally for proper concurrent
+ * rendering support.
+ *
+ * @param sessionId - Claude Code session ID to monitor
+ * @param options - Polling configuration
+ * @returns Current session state snapshot
+ *
+ * @example
+ * ```tsx
+ * function SessionViewer({ sessionId }: { sessionId: string }) {
+ *   const { events, connected, error } = useSessionUpdates(sessionId);
+ *
+ *   return (
+ *     <div>
+ *       <p>Status: {connected ? "Connected" : "Disconnected"}</p>
+ *       {error && <p className="error">{error}</p>}
+ *       {events.map((event, i) => (
+ *         <div key={event.uuid ?? i}>
+ *           <strong>{event.type}</strong>: {JSON.stringify(event.content)}
+ *         </div>
+ *       ))}
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useSessionUpdates(
+  sessionId: string,
+  options?: {
+    pollingIntervalMs?: number;
+    includeExisting?: boolean;
+  },
+): SessionStoreSnapshot {
+  // Create stable store reference
+  const storeRef = useRef<SessionStore | null>(null);
+
+  if (storeRef.current === null || storeRef.current.getSnapshot().sessionId !== sessionId) {
+    storeRef.current = new SessionStore(sessionId, options);
+  }
+
+  const store = storeRef.current;
+
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getServerSnapshot,
+  );
+}
+
+// ============================================================
+// Pattern 3: Example Component
+// ============================================================
+
+/**
+ * SessionViewer component - displays live session events.
+ *
+ * @example
+ * ```tsx
+ * <SessionViewer sessionId="abc-123-def" />
+ * ```
+ */
+export function SessionViewer({ sessionId }: { sessionId: string }) {
+  const { events, connected, error } = useSessionUpdates(sessionId, {
+    pollingIntervalMs: 300,
+    includeExisting: true,
+  });
+
+  const userMessages = events.filter((e) => e.type === "user");
+  const assistantMessages = events.filter((e) => e.type === "assistant");
+
+  return (
+    <div className="session-viewer">
+      <header>
+        <h2>Session: {sessionId.slice(0, 8)}...</h2>
+        <span className={connected ? "status-connected" : "status-disconnected"}>
+          {connected ? "Live" : "Disconnected"}
+        </span>
+        <span>Events: {events.length}</span>
+        <span>User: {userMessages.length}</span>
+        <span>Assistant: {assistantMessages.length}</span>
+      </header>
+
+      {error !== null && (
+        <div className="error-banner">Error: {error}</div>
+      )}
+
+      <div className="event-list">
+        {events.map((event, index) => (
+          <div
+            key={event.uuid ?? `event-${index}`}
+            className={`event event-${event.type}`}
+          >
+            <div className="event-header">
+              <span className="event-type">{event.type}</span>
+              {event.timestamp && (
+                <time className="event-time">
+                  {new Date(event.timestamp).toLocaleTimeString()}
+                </time>
+              )}
+            </div>
+            <pre className="event-content">
+              {typeof event.content === "string"
+                ? event.content
+                : JSON.stringify(event.content, null, 2)}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * SessionList component - lists sessions and allows selection.
+ *
+ * Demonstrates combining SessionReader (for listing) with
+ * SessionUpdateReceiver (for live monitoring).
+ */
+export function SessionListWithViewer() {
+  const selectedRef = useRef<string | null>(null);
+
+  // In a real app, you would fetch sessions from the REST API:
+  //   const sessions = useFetch("/api/sessions");
+
+  return (
+    <div className="session-app">
+      <aside className="session-sidebar">
+        <h3>Sessions</h3>
+        <p>Select a session to view live updates</p>
+        {/* Session list would go here */}
+      </aside>
+
+      <main className="session-main">
+        {selectedRef.current ? (
+          <SessionViewer sessionId={selectedRef.current} />
+        ) : (
+          <p>Select a session from the sidebar</p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/examples/sse-bridge.ts
+++ b/examples/sse-bridge.ts
@@ -1,0 +1,189 @@
+/**
+ * SSE Bridge Example
+ *
+ * Demonstrates how to bridge SessionUpdateReceiver's polling-based
+ * updates into Server-Sent Events for real-time client connections.
+ *
+ * This pattern is useful when building web UIs that need to display
+ * live session progress without client-side polling.
+ *
+ * Prerequisites:
+ *   bun add claude-code-agent
+ *
+ * @example
+ * ```bash
+ * bun run examples/sse-bridge.ts
+ * ```
+ */
+
+import {
+  SessionUpdateReceiver,
+  type SessionUpdate,
+  type TranscriptEvent,
+  type ISessionUpdateReceiver,
+} from "claude-code-agent/sdk";
+
+// --- SSE Bridge ---
+
+/**
+ * SSEBridge converts polling-based SessionUpdateReceiver into
+ * a Server-Sent Events stream.
+ *
+ * Usage:
+ * ```typescript
+ * const bridge = new SSEBridge(sessionId);
+ * const stream = bridge.createStream();
+ * return new Response(stream, {
+ *   headers: { "Content-Type": "text/event-stream" }
+ * });
+ * ```
+ */
+class SSEBridge {
+  private receiver: ISessionUpdateReceiver;
+  private aborted: boolean = false;
+
+  constructor(
+    sessionId: string,
+    options?: {
+      pollingIntervalMs?: number;
+      includeExisting?: boolean;
+    },
+  ) {
+    this.receiver = new SessionUpdateReceiver(sessionId, {
+      pollingIntervalMs: options?.pollingIntervalMs ?? 300,
+      includeExisting: options?.includeExisting ?? true,
+    });
+  }
+
+  /**
+   * Create a ReadableStream that emits SSE-formatted data.
+   *
+   * Each TranscriptEvent is sent as a separate SSE message with:
+   *   - event: the transcript event type
+   *   - data: JSON-serialized event object
+   *   - id: event UUID (if available)
+   */
+  createStream(): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    const receiver = this.receiver;
+    const bridge = this;
+
+    return new ReadableStream({
+      async pull(controller) {
+        if (bridge.aborted) {
+          controller.close();
+          return;
+        }
+
+        const update: SessionUpdate | null = await receiver.receive();
+        if (update === null) {
+          // Session ended or receiver closed
+          controller.enqueue(
+            encoder.encode("event: close\ndata: {}\n\n"),
+          );
+          controller.close();
+          return;
+        }
+
+        for (const event of update.events) {
+          const sseMessage = formatSSEMessage(event);
+          controller.enqueue(encoder.encode(sseMessage));
+        }
+      },
+
+      cancel() {
+        bridge.abort();
+      },
+    });
+  }
+
+  /**
+   * Stop the bridge and close the receiver.
+   */
+  abort(): void {
+    this.aborted = true;
+    this.receiver.close();
+  }
+}
+
+/**
+ * Format a TranscriptEvent as an SSE message string.
+ *
+ * @param event - Transcript event to format
+ * @returns SSE-formatted string
+ */
+function formatSSEMessage(event: TranscriptEvent): string {
+  const lines: string[] = [];
+
+  // Set event type
+  lines.push(`event: ${event.type}`);
+
+  // Set ID if available
+  if (event.uuid) {
+    lines.push(`id: ${event.uuid}`);
+  }
+
+  // Set data (JSON payload)
+  const data = JSON.stringify({
+    type: event.type,
+    uuid: event.uuid,
+    timestamp: event.timestamp,
+    content: event.content,
+  });
+  lines.push(`data: ${data}`);
+
+  // SSE messages are terminated by double newline
+  return lines.join("\n") + "\n\n";
+}
+
+// --- Standalone HTTP server using Bun.serve ---
+
+/**
+ * Manages active SSE connections per session.
+ */
+const activeBridges = new Map<string, SSEBridge>();
+
+const server = Bun.serve({
+  port: 3001,
+
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+
+    // GET /stream/:sessionId - Start SSE stream
+    const match = url.pathname.match(/^\/stream\/(.+)$/);
+    if (match?.[1]) {
+      const sessionId = match[1];
+
+      const bridge = new SSEBridge(sessionId, {
+        pollingIntervalMs: 200,
+        includeExisting: true,
+      });
+
+      activeBridges.set(sessionId, bridge);
+
+      const stream = bridge.createStream();
+
+      // Clean up when client disconnects
+      req.signal.addEventListener("abort", () => {
+        bridge.abort();
+        activeBridges.delete(sessionId);
+      });
+
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+});
+
+console.log(`SSE Bridge server running at http://localhost:${server.port}`);
+console.log("Connect to: GET /stream/:sessionId");
+
+export { SSEBridge, formatSSEMessage };

--- a/examples/svelte5-store.ts
+++ b/examples/svelte5-store.ts
@@ -1,0 +1,240 @@
+/**
+ * Svelte 5 Integration Example
+ *
+ * Demonstrates how to consume SessionUpdateReceiver in Svelte 5
+ * with proper reactivity using $state bridges.
+ *
+ * Svelte 5 runes ($state, $derived) cannot track property changes
+ * on plain JavaScript objects returned by the SDK. This example shows
+ * the recommended pattern for bridging SDK state into Svelte reactivity.
+ *
+ * NOTE: This file contains TypeScript patterns that would be used
+ * inside .svelte files with <script lang="ts"> blocks.
+ * It is provided as .ts for reference and type checking.
+ *
+ * Prerequisites:
+ *   bun add claude-code-agent
+ */
+
+import type {
+  ISessionUpdateReceiver,
+  SessionUpdate,
+  TranscriptEvent,
+} from "claude-code-agent/sdk";
+import {
+  SessionUpdateReceiver,
+  createSessionReceiver,
+} from "claude-code-agent/sdk";
+
+// ============================================================
+// Pattern 1: Reactive Session Store
+// ============================================================
+
+/**
+ * Creates a reactive session store that bridges SDK polling
+ * into Svelte 5 $state variables.
+ *
+ * Usage in a .svelte file:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createSessionStore } from './svelte5-store';
+ *
+ *   const store = createSessionStore('session-uuid');
+ *
+ *   // These are reactive via $state
+ *   // Access: store.events, store.isConnected, store.error
+ * </script>
+ *
+ * {#each store.events as event}
+ *   <p>{event.type}: {JSON.stringify(event.content)}</p>
+ * {/each}
+ * ```
+ */
+export function createSessionStore(sessionId: string) {
+  // --- Svelte 5 $state bridge variables ---
+  // In a real .svelte file, these would use $state rune:
+  //   let events = $state<TranscriptEvent[]>([]);
+  //   let isConnected = $state(false);
+  //   let error = $state<string | null>(null);
+  //   let lastUpdate = $state<string | null>(null);
+
+  // For this .ts reference file, we use a plain object
+  // to demonstrate the pattern:
+  const state = {
+    events: [] as TranscriptEvent[],
+    isConnected: false,
+    error: null as string | null,
+    lastUpdate: null as string | null,
+  };
+
+  let receiver: ISessionUpdateReceiver | null = null;
+  let polling = false;
+
+  /**
+   * Start receiving updates.
+   * Call this in onMount() or when the component initializes.
+   */
+  async function connect(): Promise<void> {
+    if (receiver !== null) return;
+
+    receiver = createSessionReceiver(sessionId, {
+      pollingIntervalMs: 300,
+      includeExisting: true,
+    });
+
+    state.isConnected = true;
+    polling = true;
+
+    // Start polling loop
+    void pollLoop();
+  }
+
+  /**
+   * Internal polling loop.
+   * Each iteration calls receive() and syncs results to $state variables.
+   */
+  async function pollLoop(): Promise<void> {
+    while (polling && receiver !== null) {
+      try {
+        const update: SessionUpdate | null = await receiver.receive();
+
+        if (update === null) {
+          // Session ended
+          state.isConnected = false;
+          break;
+        }
+
+        // Sync to $state variables
+        // In Svelte 5, this assignment triggers reactivity:
+        //   events = [...events, ...update.events];
+        //   lastUpdate = update.timestamp;
+        state.events = [...state.events, ...update.events];
+        state.lastUpdate = update.timestamp;
+        state.error = null;
+      } catch (err) {
+        state.error = err instanceof Error ? err.message : String(err);
+      }
+    }
+  }
+
+  /**
+   * Stop receiving updates.
+   * Call this in onDestroy() or when the component unmounts.
+   */
+  function disconnect(): void {
+    polling = false;
+    if (receiver !== null) {
+      receiver.close();
+      receiver = null;
+    }
+    state.isConnected = false;
+  }
+
+  return {
+    /** Reactive state (use $state in .svelte files) */
+    state,
+    /** Start receiving updates */
+    connect,
+    /** Stop receiving updates */
+    disconnect,
+  };
+}
+
+// ============================================================
+// Pattern 2: Svelte 5 Component Example (pseudo-code)
+// ============================================================
+
+/**
+ * Example Svelte 5 component using the session store.
+ *
+ * In a real .svelte file:
+ *
+ * ```svelte
+ * <script lang="ts">
+ *   import { onMount, onDestroy } from 'svelte';
+ *   import {
+ *     SessionUpdateReceiver,
+ *     type TranscriptEvent,
+ *     type SessionUpdate,
+ *   } from 'claude-code-agent/sdk';
+ *
+ *   interface Props {
+ *     sessionId: string;
+ *   }
+ *
+ *   let { sessionId }: Props = $props();
+ *
+ *   // $state variables for reactivity bridge
+ *   let events = $state<TranscriptEvent[]>([]);
+ *   let isConnected = $state(false);
+ *   let error = $state<string | null>(null);
+ *
+ *   // Derived values work on $state variables
+ *   let messageCount = $derived(events.length);
+ *   let userMessages = $derived(
+ *     events.filter(e => e.type === 'user')
+ *   );
+ *   let assistantMessages = $derived(
+ *     events.filter(e => e.type === 'assistant')
+ *   );
+ *
+ *   let receiver: SessionUpdateReceiver | null = null;
+ *
+ *   onMount(() => {
+ *     receiver = new SessionUpdateReceiver(sessionId, {
+ *       pollingIntervalMs: 300,
+ *       includeExisting: true,
+ *     });
+ *     isConnected = true;
+ *     pollUpdates();
+ *   });
+ *
+ *   onDestroy(() => {
+ *     receiver?.close();
+ *     receiver = null;
+ *     isConnected = false;
+ *   });
+ *
+ *   async function pollUpdates() {
+ *     while (receiver && !receiver.isClosed) {
+ *       try {
+ *         const update = await receiver.receive();
+ *         if (!update) break;
+ *
+ *         // Assignment to $state triggers reactivity
+ *         events = [...events, ...update.events];
+ *         error = null;
+ *       } catch (e) {
+ *         error = e instanceof Error ? e.message : String(e);
+ *       }
+ *     }
+ *     isConnected = false;
+ *   }
+ * </script>
+ *
+ * <div class="session-viewer">
+ *   <header>
+ *     <h2>Session: {sessionId}</h2>
+ *     <span class:connected={isConnected}>
+ *       {isConnected ? 'Connected' : 'Disconnected'}
+ *     </span>
+ *     <span>Messages: {messageCount}</span>
+ *   </header>
+ *
+ *   {#if error}
+ *     <div class="error">{error}</div>
+ *   {/if}
+ *
+ *   <div class="messages">
+ *     {#each events as event (event.uuid ?? crypto.randomUUID())}
+ *       <div class="event event-{event.type}">
+ *         <span class="type">{event.type}</span>
+ *         <span class="timestamp">{event.timestamp}</span>
+ *         <pre>{JSON.stringify(event.content, null, 2)}</pre>
+ *       </div>
+ *     {/each}
+ *   </div>
+ * </div>
+ * ```
+ */
+export const SVELTE_COMPONENT_EXAMPLE = "See JSDoc above for full .svelte component example";

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -160,6 +160,14 @@ export { EventEmitter, createEventEmitter } from "./events";
 // Session Reader
 export { SessionReader } from "./session-reader";
 
+// Session Index Types (from sessions-index.json)
+export type {
+  SessionIndexEntry,
+  SessionIndex,
+  ProjectInfo,
+  SessionListResponse,
+} from "../types/session-index";
+
 // Session Update Receiver
 export {
   SessionUpdateReceiver,

--- a/src/sdk/transport/subprocess.ts
+++ b/src/sdk/transport/subprocess.ts
@@ -77,6 +77,16 @@ export interface TransportOptions {
    * These tools cannot be executed.
    */
   disallowedTools?: string[];
+
+  /**
+   * Session ID to resume. When set, CLI is invoked with --resume flag.
+   */
+  resumeSessionId?: string;
+
+  /**
+   * Initial prompt to send. When set with resumeSessionId, used as --prompt.
+   */
+  prompt?: string;
 }
 
 /**
@@ -439,6 +449,14 @@ export class SubprocessTransport implements Transport {
       this.options.disallowedTools.length > 0
     ) {
       args.push("--disallowed-tools", this.options.disallowedTools.join(","));
+    }
+
+    if (this.options.resumeSessionId !== undefined) {
+      args.push("--resume", this.options.resumeSessionId);
+    }
+
+    if (this.options.prompt !== undefined) {
+      args.push("--prompt", this.options.prompt);
     }
 
     return args;

--- a/src/types/session-index.ts
+++ b/src/types/session-index.ts
@@ -1,0 +1,50 @@
+/**
+ * Types for Claude Code's sessions-index.json files.
+ *
+ * Claude Code stores session metadata in ~/.claude/projects/<encoded-path>/sessions-index.json.
+ * These types represent the structure of those index files.
+ *
+ * @module types/session-index
+ */
+
+/**
+ * A single entry in the sessions-index.json file.
+ */
+export interface SessionIndexEntry {
+  readonly sessionId: string;
+  readonly fullPath: string;
+  readonly firstPrompt: string;
+  readonly summary: string;
+  readonly modified: string;
+  readonly created: string;
+  readonly gitBranch: string;
+  readonly projectPath: string;
+}
+
+/**
+ * The complete sessions-index.json structure.
+ */
+export interface SessionIndex {
+  readonly originalPath: string;
+  readonly entries: readonly SessionIndexEntry[];
+}
+
+/**
+ * Project information derived from session indexes.
+ */
+export interface ProjectInfo {
+  readonly path: string;
+  readonly encoded: string;
+  readonly sessionCount: number;
+  readonly lastModified: string;
+}
+
+/**
+ * Paginated response for session listing.
+ */
+export interface SessionListResponse {
+  readonly sessions: readonly SessionIndexEntry[];
+  readonly total: number;
+  readonly offset: number;
+  readonly limit: number;
+}


### PR DESCRIPTION
## Summary

Implements four GitHub issues to enhance SDK capabilities and developer experience:

- **#12**: Added `readTranscript()` method to `SessionReader` with pagination support (offset/limit), using `JsonlStreamParser` for consistent parsing
- **#13**: Created and exported session-index types (`SessionIndexEntry`, `SessionIndex`, `ProjectInfo`, `SessionListResponse`) from `src/types/session-index.ts`
- **#14**: Added `examples/` directory with integration examples for Hono REST API, SSE bridge, Svelte 5 reactive stores, and React 18+ `useSyncExternalStore`
- **#15**: Implemented actual session resume via `--resume` CLI flag: added `resumeSession()` to `ClaudeCodeToolAgent`, updated `TransportOptions`, and replaced daemon 501 stub with working endpoint

## Files Changed (12 files, +1311/-14)

| File | Change |
|------|--------|
| `src/sdk/session-reader.ts` | Added `readTranscript()` and `findSessionFilePath()` |
| `src/sdk/session-reader.test.ts` | 4 new tests for transcript reading |
| `src/types/session-index.ts` | New session-index type definitions |
| `src/sdk/index.ts` | Export session-index types |
| `src/sdk/agent.ts` | Added `resumeSession()`, updated `SessionConfig` |
| `src/sdk/transport/subprocess.ts` | Added `resumeSessionId`/`prompt` options |
| `src/daemon/routes/sessions.ts` | Implemented resume endpoint |
| `examples/hono-rest-api.ts` | Hono REST API example |
| `examples/sse-bridge.ts` | SSE bridge example |
| `examples/svelte5-store.ts` | Svelte 5 integration example |
| `examples/react-integration.tsx` | React 18+ integration example |
| `examples/README.md` | Examples documentation |

## Test plan

- [x] TypeScript type checking passes (`tsc --noEmit`)
- [x] All 74 session-reader tests pass (including 4 new readTranscript tests)
- [x] All SDK agent tests pass (62 tests)
- [x] All daemon route tests pass (5 tests)
- [x] No regressions in existing functionality

Closes #12, #13, #14, #15