### PR TITLE
fix: extract content from message.content for user/assistant events

### DIFF
--- a/src/polling/parser.ts
+++ b/src/polling/parser.ts
@@ -158,6 +158,13 @@ export class JsonlStreamParser {
 
       if ("content" in raw) {
         event.content = raw.content;
+      } else if (
+        "message" in raw &&
+        typeof raw.message === "object" &&
+        raw.message !== null &&
+        "content" in raw.message
+      ) {
+        event.content = raw.message.content;
       }
 
       return event;


### PR DESCRIPTION
## Summary

- Fixes `TranscriptEvent.content` being always `undefined` for user/assistant events
- Added fallback content extraction from `raw.message.content` in the JSONL parser
- Top-level `content` still takes precedence over nested `message.content`

## Root Cause

Claude Code's JSONL entries for user/assistant messages store content at `message.content`, not at the root level. The parser only checked `raw.content`, missing the nested path entirely.

## Changes

- **src/polling/parser.ts**: Added `message.content` fallback in `parseLine()` with proper type narrowing
- **src/polling/parser.test.ts**: Added 4 test cases covering user events, assistant events, precedence, and edge cases

## Test Plan

- [x] All 38 existing + new parser tests pass
- [x] TypeScript type checking passes
- [x] User events with `message.content` correctly extract content
- [x] Assistant events with array content in `message.content` correctly extract content
- [x] Top-level `content` takes precedence over `message.content`
- [x] Events with `message` but no `content` field return `undefined`

Closes #17