### PR TITLE
feat: add listSessionsByWorkingDirectory to SessionReader

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -166,6 +166,7 @@ export type {
   SessionIndex,
   ProjectInfo,
   SessionListResponse,
+  ListSessionsByPathOptions,
 } from "../types/session-index";
 
 // Session Update Receiver

--- a/src/types/session-index.ts
+++ b/src/types/session-index.ts
@@ -48,3 +48,21 @@ export interface SessionListResponse {
   readonly offset: number;
   readonly limit: number;
 }
+
+/**
+ * Options for listing sessions by working directory path.
+ */
+export interface ListSessionsByPathOptions {
+  /** Absolute path to the working directory (e.g., "/g/gits/tacogips/QraftBox") */
+  readonly workingDirectory: string;
+  /** Optional search string to filter by firstPrompt or summary */
+  readonly search?: string;
+  /** Pagination offset (default: 0) */
+  readonly offset?: number;
+  /** Pagination limit (default: 50) */
+  readonly limit?: number;
+  /** Sort field (default: "modified") */
+  readonly sortBy?: "modified" | "created";
+  /** Sort order (default: "desc") */
+  readonly sortOrder?: "asc" | "desc";
+}


### PR DESCRIPTION
## Summary

- Adds `listSessionsByWorkingDirectory(options)` method to `SessionReader` for listing sessions by working directory path
- Adds `SessionReader.encodeProjectPath()` static method for path encoding (e.g., `/g/gits/project` -> `-g-gits-project`)
- Handles missing `sessions-index.json` by building entries from JSONL files (extracting firstPrompt, summary, timestamps, gitBranch)
- Supports search filtering (case-insensitive on firstPrompt/summary), sorting (by modified/created), and pagination (offset/limit)
- Adds `ListSessionsByPathOptions` interface and exports it from the SDK

## Changes

- **src/types/session-index.ts**: Added `ListSessionsByPathOptions` interface
- **src/sdk/session-reader.ts**: Added `encodeProjectPath()`, `listSessionsByWorkingDirectory()`, and `buildEntriesFromJsonlFiles()`
- **src/sdk/index.ts**: Exported `ListSessionsByPathOptions` type
- **src/sdk/session-reader.test.ts**: Added 12 test cases covering index reading, JSONL fallback, search, sort, pagination, and path encoding

## Test Plan

- [x] All 86 session-reader tests pass (74 existing + 12 new)
- [x] TypeScript type checking passes
- [x] Returns sessions from sessions-index.json when available
- [x] Builds entries from JSONL files when sessions-index.json is missing
- [x] Search filters on firstPrompt and summary (case-insensitive)
- [x] Sort by modified/created in asc/desc order
- [x] Pagination with offset and limit works correctly
- [x] Returns empty result for non-existent directories
- [x] Path encoding produces correct encoded names

Closes #19