### PR TITLE
fix: resolve multiple SDK agent bugs preventing session completion

### DIFF
--- a/src/sdk/control-protocol.ts
+++ b/src/sdk/control-protocol.ts
@@ -281,6 +281,38 @@ export class ControlProtocolHandler extends EventEmitter {
         return;
       }
 
+      // Check if it's a session result message (CLI has finished)
+      if (
+        typeof msg === "object" &&
+        msg !== null &&
+        "type" in msg &&
+        (msg as { type: unknown }).type === "result"
+      ) {
+        const resultMsg = msg as {
+          subtype?: string;
+          is_error?: boolean;
+          result?: string;
+        };
+        const success =
+          resultMsg.subtype === "success" && resultMsg.is_error !== true;
+        this.emit("result", {
+          success,
+          result: resultMsg.result,
+          raw: msg,
+        });
+        return;
+      }
+
+      // Other known message types (system, assistant) are handled via the "message" event
+      if (
+        typeof msg === "object" &&
+        msg !== null &&
+        "type" in msg &&
+        typeof (msg as { type: unknown }).type === "string"
+      ) {
+        return;
+      }
+
       // Unknown message type - log warning
       logger.warn("Unknown message type received", { msg });
     } catch (error) {


### PR DESCRIPTION
## Summary

Fixes four critical bugs in `src/sdk/agent.ts` and `src/sdk/control-protocol.ts` that prevented sessions from completing when used via external applications (e.g., QraftBox). All four bugs needed to be fixed together for end-to-end session operation.

Closes #23

## Changes

### File Change Statistics

| File | Changes | Insertions | Deletions |
|------|---------|------------|-----------|
| `src/sdk/agent.ts` | M | +116 | -12 |
| `src/sdk/control-protocol.ts` | M | +32 | -0 |
| **Total** | **2 files** | **+148** | **-12** |

### Bug 1: Deadlock in `startSession()` - `processMessages()` called after `initialize()`

**File:** `src/sdk/agent.ts` (`startSession` method)

`processMessages()` was started AFTER `initialize()`, but `initialize()` sends a control request and waits for a response. Responses are only read by `processMessages()`. This caused a deadlock where `initialize()` would time out after 30 seconds.

**Fix:** Moved `processMessages()` before `initialize()` and created `SessionStateManager` early so the processMessages completion handler can update state.

### Bug 2: Wrong user message format

**File:** `src/sdk/agent.ts` (`startSession` method)

The agent sent `{"type":"user","content":"hello"}` but the CLI expects `{"type":"user","message":{"role":"user","content":"hello"}}`.

**Fix:** Changed message format to include nested `message` object with `role` field.

### Bug 3: ReadableStream reader conflict between `processMessages()` and `messages()`

**File:** `src/sdk/agent.ts` (`messages` method)

Both `processMessages()` and `messages()` tried to call `this.transport.readMessages()` which calls `this.stdout.getReader()`. A ReadableStream can only have one active reader, causing a runtime error.

**Fix:** Rewrote `messages()` to use an event-based queue pattern. It now listens to protocol "message" events instead of reading from transport directly. Uses a promise-based queue with proper cleanup via `finally` block.

### Bug 4: Session never transitions to completed state

**File:** `src/sdk/control-protocol.ts` and `src/sdk/agent.ts`

When the CLI sends a `{"type":"result","subtype":"success"}` message indicating completion, nothing transitioned the `SessionStateManager` to a terminal state. The session would stay in "running" state forever.

**Fix:** Added "result" message detection in `handleIncomingMessage()` which emits a "result" event, and a listener in `startSession()` that transitions the state manager to completed/failed based on the result.

## Test plan

- [x] All 1350 SDK tests pass (0 failures)
- [x] TypeScript type checking passes with no errors
- [x] Full test suite passes (2460+ tests, 0 failures)
- [x] Verified the pre-existing failing test (`ViewerServer > GET /`) is unrelated and intermittent