### PR TITLE
feat: implement robust cancel and abort for running SDK sessions

### DIFF
--- a/src/sdk/session-state.test.ts
+++ b/src/sdk/session-state.test.ts
@@ -70,7 +70,7 @@ describe("SessionStateManager", () => {
 
       expect(() => {
         manager.transition("completed");
-      }).toThrow("Invalid state: idle. Expected one of: starting");
+      }).toThrow("Invalid state: idle. Expected one of: starting, cancelled");
     });
 
     it("should merge metadata into state info", () => {

--- a/src/sdk/session-state.ts
+++ b/src/sdk/session-state.ts
@@ -44,8 +44,8 @@ interface PendingOperation {
  * Defines which states can transition to which other states.
  */
 const VALID_TRANSITIONS: Record<SessionState, readonly SessionState[]> = {
-  idle: ["starting"],
-  starting: ["running", "failed"],
+  idle: ["starting", "cancelled"],
+  starting: ["running", "failed", "cancelled"],
   running: [
     "waiting_tool_call",
     "waiting_permission",

--- a/src/sdk/transport/subprocess.ts
+++ b/src/sdk/transport/subprocess.ts
@@ -455,9 +455,9 @@ export class SubprocessTransport implements Transport {
       args.push("--resume", this.options.resumeSessionId);
     }
 
-    if (this.options.prompt !== undefined) {
-      args.push("--prompt", this.options.prompt);
-    }
+    // Note: --prompt is not a supported CLI flag.
+    // For resume sessions with a prompt, the prompt is sent via stdin
+    // as a user message after initialization (handled in agent.ts).
 
     return args;
   }


### PR DESCRIPTION
## Summary

- Implement robust `cancel()` method for `ToolAgentSession` that gracefully stops running prompts by sending an interrupt signal with a 3-second timeout, then force-closing the transport. Safe to call from any non-terminal state (idle, starting, running, waiting, paused) and idempotent on terminal states.
- Add new `abort()` method for force-cancellation without sending an interrupt signal, for cases when the CLI subprocess is completely unresponsive.
- Expand state machine to allow `idle -> cancelled` and `starting -> cancelled` transitions, enabling cancel during session initialization.
- Fix `activeSessions` map cleanup: sessions are now removed on any terminal state transition (completed/failed/cancelled), not only via `waitForCompletion()`.
- Fix race conditions in `processMessages()` completion handlers with try-catch to prevent `InvalidStateError` when concurrent cancel operations have already transitioned the state.
- Fix prompt handling for resumed sessions: prompts are now sent via stdin as user messages for both new and resumed sessions, removing the invalid `--prompt` CLI flag.

## File Changes

| File | Changes | Description |
|------|---------|-------------|
| `src/sdk/agent.ts` | +89/-7 | Robust cancel/abort, cleanup listeners, prompt fix |
| `src/sdk/session-state.ts` | +2/-2 | State machine: idle/starting -> cancelled |
| `src/sdk/session-state.test.ts` | +1/-1 | Updated error message expectation |
| `src/sdk/transport/subprocess.ts` | +3/-3 | Removed invalid --prompt CLI flag |

## Test Plan

- [x] Existing tests pass (144/144, type check clean)
- [ ] Add unit tests for `cancel()` with mock transport (graceful path)
- [ ] Add unit tests for `cancel()` when interrupt times out
- [ ] Add unit tests for `abort()` with mock transport
- [ ] Add unit tests for cancel/abort on already-terminal sessions (no-op)
- [ ] Add unit tests for `idle -> cancelled` and `starting -> cancelled` transitions
- [ ] Add integration test for cancel during active tool call
- [ ] Add test for `activeSessions` cleanup after cancel