### PR TITLE
Add custom CLI arguments support and robust session cancellation

### DIFF
--- a/src/repository/queue-repository.ts
+++ b/src/repository/queue-repository.ts
@@ -84,6 +84,8 @@ export interface CommandQueue {
   readonly startedAt?: string | undefined;
   /** ISO timestamp when completed */
   readonly completedAt?: string | undefined;
+  /** Additional CLI arguments to pass to Claude Code (e.g., ['--dangerously-skip-permissions']) */
+  readonly additionalArgs?: readonly string[] | undefined;
 }
 
 /**

--- a/src/sdk/agent.ts
+++ b/src/sdk/agent.ts
@@ -202,6 +202,8 @@ export interface ToolAgentOptions {
   cliPath?: string;
   /** Default timeout for operations in ms */
   defaultTimeout?: number;
+  /** Additional CLI arguments to pass to Claude Code (e.g., ['--dangerously-skip-permissions']) */
+  additionalArgs?: string[];
 }
 
 /**
@@ -790,6 +792,8 @@ export class ClaudeCodeToolAgent {
       options.allowedTools = this.options.allowedTools;
     if (this.options.disallowedTools !== undefined)
       options.disallowedTools = this.options.disallowedTools;
+    if (this.options.additionalArgs !== undefined)
+      options.additionalArgs = this.options.additionalArgs;
 
     return options;
   }

--- a/src/sdk/group/session-processor.ts
+++ b/src/sdk/group/session-processor.ts
@@ -70,6 +70,15 @@ export async function startGroupSession(
   // See src/sdk/queue/runner.ts for detailed description of the planned enhancement.
   // Summary: Reuse long-lived processes via /clear instead of spawning new processes.
   const args = ["-p", "--output-format", "stream-json"];
+
+  // Pass additional CLI arguments from group config
+  if (
+    group.config.additionalArgs !== undefined &&
+    group.config.additionalArgs.length > 0
+  ) {
+    args.push(...group.config.additionalArgs);
+  }
+
   if (resumeFlag) {
     args.push("--resume");
   }

--- a/src/sdk/group/types.ts
+++ b/src/sdk/group/types.ts
@@ -94,6 +94,8 @@ export interface GroupConfig {
   readonly onBudgetExceeded: "stop" | "warn" | "pause";
   /** Budget warning threshold (0-1) */
   readonly warningThreshold: number;
+  /** Additional CLI arguments to pass to Claude Code (e.g., ['--dangerously-skip-permissions']) */
+  readonly additionalArgs?: readonly string[] | undefined;
   /** Concurrency settings */
   readonly concurrency?: ConcurrencyConfig | undefined;
   /** Default session configuration */

--- a/src/sdk/queue/runner.ts
+++ b/src/sdk/queue/runner.ts
@@ -562,6 +562,14 @@ export class QueueRunner {
     // See: design-docs/reference-claude-code-internals.md for CLI options.
     const args: string[] = ["-p", "--output-format", "stream-json"];
 
+    // Append additional CLI arguments from queue configuration
+    if (
+      queue.additionalArgs !== undefined &&
+      queue.additionalArgs.length > 0
+    ) {
+      args.push(...queue.additionalArgs);
+    }
+
     // Add --resume flag if continuing session
     if (!shouldStartNewSession) {
       args.push("--resume");

--- a/src/sdk/transport/subprocess.ts
+++ b/src/sdk/transport/subprocess.ts
@@ -87,6 +87,13 @@ export interface TransportOptions {
    * Initial prompt to send. When set with resumeSessionId, used as --prompt.
    */
   prompt?: string;
+
+  /**
+   * Additional CLI arguments to pass to Claude Code.
+   * These are appended as-is to the command line.
+   * Example: ['--dangerously-skip-permissions', '--model', 'claude-opus-4-6']
+   */
+  additionalArgs?: string[];
 }
 
 /**
@@ -453,6 +460,14 @@ export class SubprocessTransport implements Transport {
 
     if (this.options.resumeSessionId !== undefined) {
       args.push("--resume", this.options.resumeSessionId);
+    }
+
+    // Append additional CLI arguments as-is
+    if (
+      this.options.additionalArgs !== undefined &&
+      this.options.additionalArgs.length > 0
+    ) {
+      args.push(...this.options.additionalArgs);
     }
 
     // Note: --prompt is not a supported CLI flag.


### PR DESCRIPTION
## Summary

This PR enhances the SDK with two critical capabilities: support for custom CLI arguments across all execution modes, and robust session cancellation that works reliably from any state. The additionalArgs feature enables SDK users to pass arbitrary Claude Code CLI flags without modifying SDK internals, while the improved cancel/abort functionality resolves multiple issues with hanging cancellations and session cleanup.

## Changes

- Added additionalArgs field to all SDK interfaces (ToolAgentOptions, GroupConfig, CommandQueue, TransportOptions) to enable custom CLI argument forwarding
- Implemented CLI argument injection in all execution paths: agent sessions, queue runner, and session group processor
- Rewrote cancel() method with timeout-bounded interrupt (3 seconds) to prevent indefinite hangs on unresponsive CLI processes
- Added abort() method for force-cancellation without graceful interrupt attempt
- Extended state machine to allow cancellation from idle and starting states
- Fixed activeSessions cleanup by adding stateChange listener that triggers on any terminal state
- Hardened state transition error handling with try-catch blocks to prevent race conditions
- Fixed prompt handling for resumed sessions by sending prompts via stdin instead of invalid --prompt flag
- Made cancel/abort operations idempotent (no-op on terminal states)

## Changed Files

| File | Additions | Deletions | Change Summary |
|------|-----------|-----------|----------------|
| src/sdk/agent.ts | 100 | 12 | Add additionalArgs support and rewrite cancel/abort logic |
| src/sdk/transport/subprocess.ts | 17 | 2 | Add additionalArgs field and remove invalid --prompt flag |
| src/sdk/queue/runner.ts | 8 | 0 | Inject additionalArgs into CLI arguments |
| src/sdk/group/session-processor.ts | 9 | 0 | Forward additionalArgs from group config |
| src/repository/queue-repository.ts | 2 | 0 | Add additionalArgs to CommandQueue interface |
| src/sdk/group/types.ts | 2 | 0 | Add additionalArgs to GroupConfig interface |
| src/sdk/session-state.ts | 2 | 2 | Allow cancel from idle and starting states |
| src/sdk/session-state.test.ts | 1 | 1 | Update test expectations for new transitions |

## Technical Details

### Custom CLI Arguments (additionalArgs)

The new additionalArgs field accepts an array of strings that are appended to the Claude Code CLI invocation. This enables advanced use cases such as:

- Permission bypassing in containerized environments: ['--dangerously-skip-permissions']
- Custom model selection: ['--model', 'claude-opus-4-6']
- Any other Claude Code CLI flags without hardcoding them

The feature is fully backward compatible (optional field with undefined default) and works across all SDK execution modes.

### Robust Cancellation

The previous cancel implementation had several critical issues:
- Could not cancel from idle/starting states (threw InvalidStateError)
- Would hang indefinitely if CLI was unresponsive to interrupt signal
- Leaked sessions in activeSessions map when cancelled from early states
- Threw errors when called on already-terminal sessions

The new implementation:
- Graceful cancel: Sends interrupt with 3-second timeout, proceeds with cleanup regardless
- Force abort: Skips interrupt signal entirely and kills subprocess immediately
- State machine expansion: Idle and starting states can now transition to cancelled
- Idempotent: Safe to call multiple times, no-op on terminal states
- Comprehensive cleanup: stateChange listener ensures activeSessions cleanup on any terminal state
- Race condition hardening: try-catch blocks prevent concurrent state transition errors

### State Transition Changes

Before:
- idle: ["starting"]
- starting: ["running", "failed"]

After:
- idle: ["starting", "cancelled"]
- starting: ["running", "failed", "cancelled"]

This allows users to cancel sessions before they've fully started executing, which is critical for responsive UI and resource management.

## Related Issues/PRs

Can add related issues or PRs here.

---

## Additional Notes

<!-- You can edit this section freely from the web interface -->
<!-- This section will be preserved when running /git-pr -->

Add your additional notes here.