### PR TITLE
fix: resolve 60-second initial prompt latency in SDK MCP integration

### DIFF
--- a/src/sdk/control-protocol.test.ts
+++ b/src/sdk/control-protocol.test.ts
@@ -126,6 +126,7 @@ describe("ControlProtocolHandler", () => {
 
       await expect(handler.initialize()).rejects.toThrow("already initialized");
     });
+
   });
 
   describe("registerToolRegistry", () => {
@@ -341,9 +342,11 @@ describe("ControlProtocolHandler", () => {
         response: {
           subtype: string;
           response: {
-            jsonrpc: string;
-            id: number;
-            result: { tools: Array<{ name: string }> };
+            mcp_response: {
+              jsonrpc: string;
+              id: number;
+              result: { tools: Array<{ name: string }> };
+            };
           };
         };
       };
@@ -351,7 +354,8 @@ describe("ControlProtocolHandler", () => {
       expect(response.type).toBe("control_response");
       expect(response.response.subtype).toBe("success");
 
-      const mcpResponse = response.response.response;
+      const mcpResponse = (response.response.response as { mcp_response: any })
+        .mcp_response;
       expect(mcpResponse.jsonrpc).toBe("2.0");
       expect(mcpResponse.id).toBe(1);
       expect(mcpResponse.result.tools).toHaveLength(1);
@@ -398,10 +402,12 @@ describe("ControlProtocolHandler", () => {
         response: {
           subtype: string;
           response: {
-            jsonrpc: string;
-            id: number;
-            result: {
-              content: Array<{ type: string; text: string }>;
+            mcp_response: {
+              jsonrpc: string;
+              id: number;
+              result: {
+                content: Array<{ type: string; text: string }>;
+              };
             };
           };
         };
@@ -410,7 +416,8 @@ describe("ControlProtocolHandler", () => {
       expect(response.type).toBe("control_response");
       expect(response.response.subtype).toBe("success");
 
-      const mcpResponse = response.response.response;
+      const mcpResponse = (response.response.response as { mcp_response: any })
+        .mcp_response;
       expect(mcpResponse.jsonrpc).toBe("2.0");
       expect(mcpResponse.id).toBe(2);
       expect(mcpResponse.result.content).toHaveLength(1);
@@ -441,14 +448,17 @@ describe("ControlProtocolHandler", () => {
         response: {
           subtype: string;
           response: {
-            jsonrpc: string;
-            id: number;
-            error: { code: number; message: string };
+            mcp_response: {
+              jsonrpc: string;
+              id: number;
+              error: { code: number; message: string };
+            };
           };
         };
       };
 
-      const mcpResponse = response.response.response;
+      const mcpResponse = (response.response.response as { mcp_response: any })
+        .mcp_response;
       expect(mcpResponse.error).toBeDefined();
       expect(mcpResponse.error.message).toContain("Server not found");
     });
@@ -478,17 +488,20 @@ describe("ControlProtocolHandler", () => {
         response: {
           subtype: string;
           response: {
-            jsonrpc: string;
-            id: number;
-            result: {
-              content: Array<{ type: string; text: string }>;
-              isError: boolean;
+            mcp_response: {
+              jsonrpc: string;
+              id: number;
+              result: {
+                content: Array<{ type: string; text: string }>;
+                isError: boolean;
+              };
             };
           };
         };
       };
 
-      const mcpResponse = response.response.response;
+      const mcpResponse = (response.response.response as { mcp_response: any })
+        .mcp_response;
       expect(mcpResponse.result.isError).toBe(true);
       expect(mcpResponse.result.content[0]?.text).toContain("not found");
     });
@@ -529,17 +542,20 @@ describe("ControlProtocolHandler", () => {
         response: {
           subtype: string;
           response: {
-            jsonrpc: string;
-            id: number;
-            result: {
-              content: Array<{ type: string; text: string }>;
-              isError: boolean;
+            mcp_response: {
+              jsonrpc: string;
+              id: number;
+              result: {
+                content: Array<{ type: string; text: string }>;
+                isError: boolean;
+              };
             };
           };
         };
       };
 
-      const mcpResponse = response.response.response;
+      const mcpResponse = (response.response.response as { mcp_response: any })
+        .mcp_response;
       expect(mcpResponse.result.isError).toBe(true);
       expect(mcpResponse.result.content[0]?.text).toContain(
         "Tool execution failed",
@@ -567,14 +583,17 @@ describe("ControlProtocolHandler", () => {
         response: {
           subtype: string;
           response: {
-            jsonrpc: string;
-            id: number;
-            error: { code: number; message: string };
+            mcp_response: {
+              jsonrpc: string;
+              id: number;
+              error: { code: number; message: string };
+            };
           };
         };
       };
 
-      const mcpResponse = response.response.response;
+      const mcpResponse = (response.response.response as { mcp_response: any })
+        .mcp_response;
       expect(mcpResponse.error).toBeDefined();
       expect(mcpResponse.error.code).toBe(-32601);
       expect(mcpResponse.error.message).toContain("Method not found");
@@ -787,14 +806,18 @@ describe("ControlProtocolHandler", () => {
         response: {
           subtype: string;
           response: {
-            result: {
-              content: Array<{ type: string; text: string }>;
+            mcp_response: {
+              result: {
+                content: Array<{ type: string; text: string }>;
+              };
             };
           };
         };
       };
 
-      expect(response.response.response.result.content[0]?.text).toBe(
+      const mcpResponse = (response.response.response as { mcp_response: any })
+        .mcp_response;
+      expect(mcpResponse.result.content[0]?.text).toBe(
         "Result: 42",
       );
     });

--- a/src/sdk/control-protocol.ts
+++ b/src/sdk/control-protocol.ts
@@ -172,7 +172,6 @@ export class ControlProtocolHandler extends EventEmitter {
     }
 
     logger.debug("Initializing control protocol");
-
     const response = await this.sendRequest({ subtype: "initialize" });
 
     if (response.response.subtype === "error") {
@@ -445,7 +444,9 @@ export class ControlProtocolHandler extends EventEmitter {
           payload.server_name,
           payload.message,
         );
-        await this.sendControlResponse(request_id, mcpResponse);
+        await this.sendControlResponse(request_id, {
+          mcp_response: mcpResponse,
+        });
       } else if (payload.subtype === "can_use_tool") {
         // Emit event for permission callback
         // For now, auto-approve all tools


### PR DESCRIPTION
## Summary

Fixes a critical 60-second timeout issue when using MCP (Model Context Protocol) with the SDK. The root cause was an incorrect control protocol response format in `control-protocol.ts` that prevented the CLI from recognizing MCP responses, causing it to wait until timeout.

## Changes

- **src/sdk/control-protocol.ts**: Fix MCP message response format by wrapping response in `{ mcp_response: ... }` object to match CLI expectations
- **src/sdk/agent.ts**: Clean up initialization flow and documentation comments - initial prompt now sent via stdin after protocol initialization
- **src/sdk/control-protocol.test.ts**: Update all MCP message response assertions to expect `response.mcp_response` wrapper format
- **src/sdk/agent.test.ts**: Add tests verifying initial prompt is NOT passed via transport options and IS sent via stdin after initialize

## Changed Files

| File | Additions | Deletions | Change Summary |
| ---- | --------- | --------- | -------------- |
| src/sdk/agent.test.ts | 68 | 1 | Add initialization flow tests |
| src/sdk/control-protocol.test.ts | 55 | 32 | Fix MCP response assertions |
| src/sdk/control-protocol.ts | 3 | 2 | Wrap MCP response format |
| src/sdk/agent.ts | 3 | 6 | Update comments and flow |

## Technical Details

**Root Cause**: The control protocol handler was sending MCP responses with incorrect format:
```typescript
// Before (incorrect):
await this.sendControlResponse(request_id, mcpResponse);

// After (correct):
await this.sendControlResponse(request_id, { mcp_response: mcpResponse });
```

The CLI expected responses in the format `{ mcp_response: { jsonrpc: "2.0", ... } }` but was receiving `{ jsonrpc: "2.0", ... }` directly. This mismatch caused the CLI to not recognize the response and wait for the full 60-second timeout on every MCP message.

**Impact**: SDK tool execution with MCP now works with immediate response times instead of 60-second delays on first prompt.

## Related Issues/PRs

- https://github.com/tacogips/claude-code-agent/issues/32

---

## Additional Notes

<!-- You can edit this section freely from the web interface -->
<!-- This section will be preserved when running /git-pr -->

This fix restores normal SDK MCP operation. The two-commit history shows the evolution: first attempting to pass the initial prompt via CLI argument (commit 0049661), then discovering and fixing the actual root cause in the control protocol response format (commit d3dd758).
