### PR TITLE
revert: undo issue #34 fix - positional prompt arg ignored with --input-format stream-json

### DIFF
--- a/src/sdk/agent.ts
+++ b/src/sdk/agent.ts
@@ -568,13 +568,6 @@ export class ClaudeCodeToolAgent {
       }
     }
 
-    // Pass prompt as positional CLI argument so CLI processes it immediately
-    // on startup, rather than relying on stdin delivery which may race with
-    // CLI initialization (see issue #34).
-    if (config.prompt !== "") {
-      transportOptions.prompt = config.prompt;
-    }
-
     const transport = new SubprocessTransport(transportOptions);
     await transport.connect();
 
@@ -624,9 +617,18 @@ export class ClaudeCodeToolAgent {
     // Initialize control protocol
     await protocol.initialize();
 
-    // NOTE: The initial prompt is now passed as a positional CLI argument
-    // (via transportOptions.prompt) so it is processed immediately on startup.
-    // Do NOT also send it via stdin to avoid double-processing (issue #34).
+    // Send initial prompt through stream-json stdin after initialize.
+    if (config.prompt !== "") {
+      await transport.write(
+        JSON.stringify({
+          type: "user",
+          message: {
+            role: "user",
+            content: config.prompt,
+          },
+        }),
+      );
+    }
 
     // Create session instance
     const session = new ToolAgentSession(


### PR DESCRIPTION
## Summary

Reverts the functional changes from PR #35 (commit 75d2b18) that attempted to fix #34.

### Why revert

Integration testing against Claude CLI 2.1.37 revealed that when `--input-format stream-json` is active (required by the control protocol), **the positional prompt argument is silently ignored**. The stdin approach (sending a user message via stdin after `protocol.initialize()`) works correctly for both new and resumed sessions.

| Scenario | Result |
|----------|--------|
| `--input-format stream-json` + positional prompt arg | Prompt **silently ignored** |
| `--input-format stream-json` + stdin user msg after `initialize()` | Works (new session) |
| `--input-format stream-json` + stdin user msg + `--resume` | Works (resumed session) |
| No `--input-format stream-json` + positional arg | Works (QueueRunner path) |

### Changes

- `src/sdk/agent.ts`: Remove `transportOptions.prompt` setting, restore stdin user message write after `initialize()`
- `src/sdk/agent.test.ts`: Restore tests verifying prompt is NOT on transport options and IS sent via stdin

Prettier formatting improvements from PR #35 are preserved.

## Test plan

- [x] All 2473 tests pass
- [x] Prettier formatting check passes
- [x] Manual integration test: new session with stdin prompt delivery works
- [x] Manual integration test: resume session with stdin prompt delivery works
- [x] Verified positional prompt arg is ignored with `--input-format stream-json`